### PR TITLE
提高绕过NDM下载成功率，修复一些Bug

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -1,162 +1,1157 @@
 var blockedHosts = [];
-// 临时放行的 URL 白名单，使用 Set 存储
-const tempWhitelist = new Set();
+var bgInstance = null;
+
+//var count = 0;
+
+function sendDownloadLink(url, pageUrl, title) {
+  if (!bgInstance || !url) return;
+  var req = new T();
+  req["2"] = url;
+  req.pageUrl = pageUrl || "";
+  req["4"] = title || "";
+  req["5"] = req.pageUrl;
+  req["6"] = "normal";
+  bgInstance.i = req;
+  chrome.cookies.getAll({ url: req["2"] }, bgInstance.J.bind(bgInstance));
+}
+
+// 从 chrome.storage.local 加载 blockedHosts，并保持内存中列表更新。
 function updateBlockedHosts() {
-    chrome.storage.local.get(['blockedHosts'], function (result) {
-        blockedHosts = result.blockedHosts || [];
+  chrome.storage.local.get(["blockedHosts"], function (result) {
+    blockedHosts = result.blockedHosts || [];
+    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+      if (tabs && tabs.length) {
+        updateContextMenu(tabs[0].id);
+      }
     });
+  });
 }
 updateBlockedHosts();
 chrome.storage.onChanged.addListener(function (changes, namespace) {
-    if (namespace === 'local' && changes.blockedHosts) {
-        updateBlockedHosts();
-    }
+  if (namespace === "local" && changes.blockedHosts) {
+    updateBlockedHosts();
+  }
 });
+// 若 URL 或触发者 hostname 匹配 blockedHosts 列表，则返回 true。
 function isURLBlocked(url, initiator) {
-    if (!blockedHosts || blockedHosts.length === 0) return false;
-    var uHost = "", iHost = "";
-    try { if (url) uHost = new URL(url).hostname; } catch (e) { }
-    try { if (initiator) iHost = new URL(initiator).hostname; } catch (e) { }
-    return blockedHosts.some(function (block) {
-        // More robust check: exact match or subdomain match
-        var blockRegex = new RegExp("(^|\\.)" + block.replace(/\./g, "\\.") + "$", "i");
-        return (uHost && blockRegex.test(uHost)) || (iHost && blockRegex.test(iHost));
-    });
+  if (!blockedHosts || blockedHosts.length === 0) return false;
+  var uHost = "",
+    iHost = "";
+  try {
+    if (url) uHost = new URL(url).hostname;
+  } catch (e) {}
+  try {
+    if (initiator) iHost = new URL(initiator).hostname;
+  } catch (e) {}
+  return blockedHosts.some(function (block) {
+    // 更稳健的检查：精确匹配或子域名匹配
+    var blockRegex = new RegExp(
+      "(^|\\.)" + block.replace(/\./g, "\\.") + "$",
+      "i",
+    );
+    return (
+      (uHost && blockRegex.test(uHost)) || (iHost && blockRegex.test(iHost))
+    );
+  });
 }
+// 根据当前标签页是否被屏蔽更新扩展上下文菜单标题。
 function updateContextMenu(tabId) {
-    chrome.tabs.get(tabId, function (tab) {
-        if (chrome.runtime.lastError || !tab || !tab.url) return;
-        var isBlocked = isURLBlocked(tab.url);
-        var title = isBlocked ? "Unblock downloads" : "Block downloads";
-        chrome.contextMenus.update("NDM_BlockSite", { title: title });
-    });
+  chrome.tabs.get(tabId, function (tab) {
+    if (chrome.runtime.lastError || !tab || !tab.url) return;
+    var isBlocked = isURLBlocked(tab.url);
+    var title = isBlocked ? "Unblock downloads" : "Block downloads";
+    chrome.contextMenus.update("NDM_BlockSite", { title: title });
+  });
 }
+// 活动标签页改变时更新菜单标题。
 chrome.tabs.onActivated.addListener(function (activeInfo) {
-    updateContextMenu(activeInfo.tabId);
+  updateContextMenu(activeInfo.tabId);
 });
-chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
-    if (changeInfo.status === 'complete' && tab.active) {
-        updateContextMenu(tabId);
-    }
-});
-chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
-    if (message.action === 'tempWhitelist' && message.url) {
-        // 标准化 URL（例如移除末尾的 / 或查询参数？但最好保留原样）
-        const url = message.url;
-        tempWhitelist.add(url);
-        //console.log('临时放行 URL:', url);
 
-        // 5 秒后自动移除
-        setTimeout(() => {
-            tempWhitelist.delete(url);
-            //console.log('临时放行过期:', url);
-        }, 5000);
-    }
+// 标签页加载完成后更新菜单标题。
+chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+  if (changeInfo.status === "complete" && tab.active) {
+    updateContextMenu(tabId);
+  }
 });
-var h = !1, q = RegExp("^bytes [0-9]+-[0-9]+/([0-9]+)$"), w = "object xmlhttprequest media other main_frame sub_frame image".split(" "), z = ["object", "xmlhttprequest", "media", "other"], A = RegExp("://.+/([^/]+?(?:.([^./]+?))?)(?=[?#]|$)"), aa = [301, 302, 303, 307, 308], ba = RegExp("^(?:application/x-apple-diskimage|application/download|application/force-download|application/x-msdownload|binary/octet-stream)$", "i"), B = RegExp("^(?:FLV|SWF|MP3|MP4|M4V|F4F|F4V|M4A|MPG|MPEG|MPEG4|MPE|AVI|WMV|WMA|WAV|WAVE|ASF|RM|RAM|OGG|OGV|OGM|OGA|MOV|MID|MIDI|3GP|3GPP|QT|WEBM|TS|MKV|AAC|MP2T|MPEGTS|RMVB|VTT|SRT)$",
-    "i"), ca = RegExp("^(?:HTM|HTML|MHT|MHTML|SHTML|SHTM|XHT|XHTM|XHTML|XML|TXT|CSS|JS|JSON|GIF|ICO|JPEG|JPG|PNG|WEBP|BMP|SVG|TIF|TIFF|PDF|PHP|ASP|ASPX|EOT|TTF|WOF|WOFF|WOFF2|MSG|PEM|BR|OTF|ACZ|AZC|CGI|TPL|OSD|M3U8|DO|DICT)$", "i"), da = RegExp("^(?:FLV|AVI|MPG|MPE|WMV|QT|MOV|RM|RAM|WMA|MID|MIDI|AAC|MKV|RMVB)$", "i"), C = RegExp("^(?:F4F|MPEGTS|TS|MP2T)$", "i"), E = {
-        "application/x-apple-diskimage": "DMG", "application/cert-chain+cbor": "MSG", "application/epub+zip": "EPUB", "application/java-archive": "JAR", "video/x-matroska": "MKV",
-        "text/html": "HTML|HTM", "text/css": "CSS", "text/javascript": "JS|JSON", "text/mspg-legacyinfo": "MSI|MSP", "text/plain": "TXT|SRT", "text/srt": "SRT", "text/vtt": "VTT|SRT", "text/xml": "XML|F4M|TTML", "text/x-javascript": "JS|JSON", "text/x-json": "JSON", "application/f4m+xml": "F4M", "application/gzip": "GZ", "application/javascript": "JS", "application/json": "JSON", "application/msword": "DOC|DOCX|DOT|DOTX", "application/pdf": "PDF", "application/ttaf+xml": "DFXP", "application/vnd.apple.mpegurl": "M3U8", "application/zip": "ZIP",
-        "application/x-7z-compressed": "7Z", "application/x-aim": "PLJ", "application/x-compress": "Z", "application/x-compress-7z": "7Z", "application/x-compressed": "ARJ", "application/x-gtar": "TAR", "application/x-msi": "MSI", "application/x-msp": "MSP", "application/x-gzip": "GZ", "application/x-gzip-compressed": "GZ", "application/x-javascript": "JS", "application/x-mpegurl": "M3U8", "application/x-msdos-program": "EXE|DLL", "application/vnd.apple.installer+xml": "MPKG", "application/x-ole-storage": "MSI|MSP", "application/x-rar": "RAR",
-        "application/x-rar-compressed": "RAR", "application/x-sdlc": "EXE|SDLC", "application/x-shockwave-flash": "SWF", "application/x-silverlight-app": "XAP", "application/x-subrip": "SRT", "application/x-tar": "TAR", "application/x-zip": "ZIP", "application/x-zip-compressed": "ZIP", "video/3gpp": "3GP|3GPP", "video/3gpp2": "3GP|3GPP", "video/avi": "AVI", "video/f4f": "F4F", "video/f4m": "F4M", "video/flv": "FLV", "video/mp2t": "TS|M3U8", "video/mp4": "MP4|M4V", "video/mpeg": "MPG|MPEG|MPE", "video/mpegurl": "M3U8|M3U", "video/mpg4": "MP4|M4V",
-        "video/msvideo": "AVI", "video/quicktime": "MOV|QT", "video/webm": "WEBM", "video/x-flash-video": "FLV", "video/x-flv": "FLV", "video/x-mp4": "MP4|M4V", "video/x-mpegurl": "M3U8|M3U", "video/x-mpg4": "MP4|M4V", "video/x-ms-asf": "ASF", "video/x-ms-wmv": "WMV", "video/x-msvideo": "AVI", "audio/3gpp": "3GP|3GPP", "audio/3gpp2": "3GP|3GPP", "audio/mp3": "MP3", "audio/mp4": "M4A|MP4", "audio/mp4a-latm": "M4A|MP4", "audio/mpeg": "MP3", "audio/mpeg4-generic": "M4A|MP4", "audio/mpegurl": "M3U8|M3U", "image/svg+xml": "SVG|SVGZ", "audio/webm": "WEBM",
-        "audio/wav": "WAV", "audio/x-mpeg": "MP3", "audio/x-mpegurl": "M3U8|M3U", "audio/x-ms-wma": "WMA", "audio/x-wav": "WAV", "ilm/tm": "MP3", "image/gif": "GIF|GFA", "image/icon": "ICO|CUR", "image/jpg": "JPG|JPEG", "image/jpeg": "JPG|JPEG", "image/png": "PNG|APNG", "image/tiff": "TIF|TIFF", "image/vnd.microsoft.icon": "ICO|CUR", "image/webp": "WEBP", "image/x-icon": "ICO|CUR", "flv-application/octet-stream": "FLV", "image/x-xbitmap": "XBM", "audio/x-mp3": "MP3", "audio/x-hx-aac-adts": "AAC", "audio/aac": "AAC", "audio/x-aac": "AAC", "application/vnd.rn-realmedia-vbr": "RMVB"
-    };
-function F(a) { return a && unescape(a.split(";", 1).shift().trim()) || "" } function G(a) { return (a = A.exec(a)) ? a[1] || "" : "" } function K(a) { return -1 < a.indexOf(".") ? a.split(".").pop() : "" } function ea(a) { var b; a = a.toUpperCase(); for (b in E) if (-1 < E[b].split("|").indexOf(a)) return b; return "" } function L(a, b) { if (!a) return null; for (var c = 0; c < a.length; c++)if (a[c].name.toLowerCase() == b.toLowerCase()) return a[c].value || a[c].binaryValue || null; return null }
-function M() { for (var a = {}, b = 0; b < arguments.length; b++)for (var c in arguments[b]) arguments[b].hasOwnProperty(c) && (a[c] = arguments[b][c]); return a } function N(a, b) { return a && b && 0 == a.indexOf(b) } function O(a, b) { if (!a || !b) return !1; var c = a.length - b.length; return 0 <= c && a.indexOf(b, c) == c } function P(a, b) { return a && b && 0 <= a.indexOf(b) } function Q(a) { return P(a, "://") ? a.split("://", 1).shift().toLowerCase() || "" : "http" }
-async function R(a, b) { var c = null, d = {}, e, f = b && b["1"] || "GET"; if (b && (e = b.o)) for (var g = 0; g < e.length; g++)N(e[g].name.toLowerCase(), "x-") && (d[e[g].name] = e[g].value); if ("POST" == f && b) { try { S(b, b), b["10"] && (d["Content-Type"] = b["10"]) } catch (m) { } b && b.postData && (c = b.postData) } try { const m = await fetch(a["2"], { method: f, credentials: "include", headers: new Headers(d), body: c }); if (m.ok) { let u = await m.text(); (a.S || function () { })(u) } } catch (m) { } }
-function T() { this["1"] = "GET"; this["2"] = ""; this["3"] = ""; this["4"] = ""; this["5"] = ""; this["6"] = "normal"; this["7"] = 0; this["8"] = ""; this["9"] = ""; this["10"] = ""; this.cookies = this["11"] = ""; this.postData = null }
+// 处理来自内容脚本的一次性 runtime 消息（例如下载链接请求）。
+chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
+  //console.log("收到消息:", message);
+  if (message.action === "downloadLink" && message.url) {
+    var pageUrl = message.pageUrl || (sender && sender.tab && sender.tab.url) || "";
+    var title = message.title || "";
+    sendDownloadLink(message.url, pageUrl, title);
+    //console.log("Download link received:", message.url, "pageUrl:", pageUrl, "title:", title);
+  }
+});
+var h = !1,
+  q = RegExp("^bytes [0-9]+-[0-9]+/([0-9]+)$"),
+  w = "object xmlhttprequest media other main_frame sub_frame image".split(" "),
+  z = ["object", "xmlhttprequest", "media", "other"],
+  A = RegExp("://.+/([^/]+?(?:.([^./]+?))?)(?=[?#]|$)"),
+  aa = [301, 302, 303, 307, 308],
+  ba = RegExp(
+    "^(?:application/x-apple-diskimage|application/download|application/force-download|application/x-msdownload|binary/octet-stream)$",
+    "i",
+  ),
+  B = RegExp(
+    "^(?:FLV|SWF|MP3|MP4|M4V|F4F|F4V|M4A|MPG|MPEG|MPEG4|MPE|AVI|WMV|WMA|WAV|WAVE|ASF|RM|RAM|OGG|OGV|OGM|OGA|MOV|MID|MIDI|3GP|3GPP|QT|WEBM|TS|MKV|AAC|MP2T|MPEGTS|RMVB|VTT|SRT)$",
+    "i",
+  ),
+  ca = RegExp(
+    "^(?:HTM|HTML|MHT|MHTML|SHTML|SHTM|XHT|XHTM|XHTML|XML|TXT|CSS|JS|JSON|GIF|ICO|JPEG|JPG|PNG|WEBP|BMP|SVG|TIF|TIFF|PDF|PHP|ASP|ASPX|EOT|TTF|WOF|WOFF|WOFF2|MSG|PEM|BR|OTF|ACZ|AZC|CGI|TPL|OSD|M3U8|DO|DICT)$",
+    "i",
+  ),
+  da = RegExp(
+    "^(?:FLV|AVI|MPG|MPE|WMV|QT|MOV|RM|RAM|WMA|MID|MIDI|AAC|MKV|RMVB)$",
+    "i",
+  ),
+  C = RegExp("^(?:F4F|MPEGTS|TS|MP2T)$", "i"),
+  E = {
+    "application/x-apple-diskimage": "DMG",
+    "application/cert-chain+cbor": "MSG",
+    "application/epub+zip": "EPUB",
+    "application/java-archive": "JAR",
+    "video/x-matroska": "MKV",
+    "text/html": "HTML|HTM",
+    "text/css": "CSS",
+    "text/javascript": "JS|JSON",
+    "text/mspg-legacyinfo": "MSI|MSP",
+    "text/plain": "TXT|SRT",
+    "text/srt": "SRT",
+    "text/vtt": "VTT|SRT",
+    "text/xml": "XML|F4M|TTML",
+    "text/x-javascript": "JS|JSON",
+    "text/x-json": "JSON",
+    "application/f4m+xml": "F4M",
+    "application/gzip": "GZ",
+    "application/javascript": "JS",
+    "application/json": "JSON",
+    "application/msword": "DOC|DOCX|DOT|DOTX",
+    "application/pdf": "PDF",
+    "application/ttaf+xml": "DFXP",
+    "application/vnd.apple.mpegurl": "M3U8",
+    "application/zip": "ZIP",
+    "application/x-7z-compressed": "7Z",
+    "application/x-aim": "PLJ",
+    "application/x-compress": "Z",
+    "application/x-compress-7z": "7Z",
+    "application/x-compressed": "ARJ",
+    "application/x-gtar": "TAR",
+    "application/x-msi": "MSI",
+    "application/x-msp": "MSP",
+    "application/x-gzip": "GZ",
+    "application/x-gzip-compressed": "GZ",
+    "application/x-javascript": "JS",
+    "application/x-mpegurl": "M3U8",
+    "application/x-msdos-program": "EXE|DLL",
+    "application/vnd.apple.installer+xml": "MPKG",
+    "application/x-ole-storage": "MSI|MSP",
+    "application/x-rar": "RAR",
+    "application/x-rar-compressed": "RAR",
+    "application/x-sdlc": "EXE|SDLC",
+    "application/x-shockwave-flash": "SWF",
+    "application/x-silverlight-app": "XAP",
+    "application/x-subrip": "SRT",
+    "application/x-tar": "TAR",
+    "application/x-zip": "ZIP",
+    "application/x-zip-compressed": "ZIP",
+    "video/3gpp": "3GP|3GPP",
+    "video/3gpp2": "3GP|3GPP",
+    "video/avi": "AVI",
+    "video/f4f": "F4F",
+    "video/f4m": "F4M",
+    "video/flv": "FLV",
+    "video/mp2t": "TS|M3U8",
+    "video/mp4": "MP4|M4V",
+    "video/mpeg": "MPG|MPEG|MPE",
+    "video/mpegurl": "M3U8|M3U",
+    "video/mpg4": "MP4|M4V",
+    "video/msvideo": "AVI",
+    "video/quicktime": "MOV|QT",
+    "video/webm": "WEBM",
+    "video/x-flash-video": "FLV",
+    "video/x-flv": "FLV",
+    "video/x-mp4": "MP4|M4V",
+    "video/x-mpegurl": "M3U8|M3U",
+    "video/x-mpg4": "MP4|M4V",
+    "video/x-ms-asf": "ASF",
+    "video/x-ms-wmv": "WMV",
+    "video/x-msvideo": "AVI",
+    "audio/3gpp": "3GP|3GPP",
+    "audio/3gpp2": "3GP|3GPP",
+    "audio/mp3": "MP3",
+    "audio/mp4": "M4A|MP4",
+    "audio/mp4a-latm": "M4A|MP4",
+    "audio/mpeg": "MP3",
+    "audio/mpeg4-generic": "M4A|MP4",
+    "audio/mpegurl": "M3U8|M3U",
+    "image/svg+xml": "SVG|SVGZ",
+    "audio/webm": "WEBM",
+    "audio/wav": "WAV",
+    "audio/x-mpeg": "MP3",
+    "audio/x-mpegurl": "M3U8|M3U",
+    "audio/x-ms-wma": "WMA",
+    "audio/x-wav": "WAV",
+    "ilm/tm": "MP3",
+    "image/gif": "GIF|GFA",
+    "image/icon": "ICO|CUR",
+    "image/jpg": "JPG|JPEG",
+    "image/jpeg": "JPG|JPEG",
+    "image/png": "PNG|APNG",
+    "image/tiff": "TIF|TIFF",
+    "image/vnd.microsoft.icon": "ICO|CUR",
+    "image/webp": "WEBP",
+    "image/x-icon": "ICO|CUR",
+    "flv-application/octet-stream": "FLV",
+    "image/x-xbitmap": "XBM",
+    "audio/x-mp3": "MP3",
+    "audio/x-hx-aac-adts": "AAC",
+    "audio/aac": "AAC",
+    "audio/x-aac": "AAC",
+    "application/vnd.rn-realmedia-vbr": "RMVB",
+  };
+// 从头部字符串中提取第一个分号分隔的值并进行 URL 解码。
+function F(a) {
+  return (a && unescape(a.split(";", 1).shift().trim())) || "";
+}
+
+// 从 URL 路径中提取文件名或最后一段。
+function G(a) {
+  return (a = A.exec(a)) ? a[1] || "" : "";
+}
+
+// 从字符串中获取文件扩展名。
+function K(a) {
+  return -1 < a.indexOf(".") ? a.split(".").pop() : "";
+}
+// 将文件扩展名映射到已知 MIME 类型键（如果可用）。
+function ea(a) {
+  var b;
+  a = a.toUpperCase();
+  for (b in E) if (-1 < E[b].split("|").indexOf(a)) return b;
+  return "";
+}
+
+// 从头部对象数组中查找指定头部的值。
+function L(a, b) {
+  if (!a) return null;
+  for (var c = 0; c < a.length; c++)
+    if (a[c].name.toLowerCase() == b.toLowerCase())
+      return a[c].value || a[c].binaryValue || null;
+  return null;
+}
+
+// 将一个或多个对象合并到一个新对象中（浅拷贝）。
+function M() {
+  for (var a = {}, b = 0; b < arguments.length; b++)
+    for (var c in arguments[b])
+      arguments[b].hasOwnProperty(c) && (a[c] = arguments[b][c]);
+  return a;
+}
+// 如果字符串 a 以字符串 b 开头，则返回 true。
+function N(a, b) {
+  return a && b && 0 == a.indexOf(b);
+}
+
+// 如果字符串 a 以字符串 b 结尾，则返回 true。
+function O(a, b) {
+  if (!a || !b) return !1;
+  var c = a.length - b.length;
+  return 0 <= c && a.indexOf(b, c) == c;
+}
+// 如果字符串 a 包含子串 b，则返回 true。
+function P(a, b) {
+  return a && b && 0 <= a.indexOf(b);
+}
+
+// 提取并规范化 URL 协议，默认为 http。
+function Q(a) {
+  return P(a, "://") ? a.split("://", 1).shift().toLowerCase() || "" : "http";
+}
+// 使用捕获的请求详情执行后台 fetch，并保留请求头和 post 数据。
+async function R(a, b) {
+  var c = null,
+    d = {},
+    e,
+    f = (b && b["1"]) || "GET";
+  if (b && (e = b.o))
+    for (var g = 0; g < e.length; g++)
+      N(e[g].name.toLowerCase(), "x-") && (d[e[g].name] = e[g].value);
+  if ("POST" == f && b) {
+    try {
+      (S(b, b), b["10"] && (d["Content-Type"] = b["10"]));
+    } catch (m) {}
+    b && b.postData && (c = b.postData);
+  }
+  try {
+    const m = await fetch(a["2"], {
+      method: f,
+      credentials: "include",
+      headers: new Headers(d),
+      body: c,
+    });
+    if (m.ok) {
+      let u = await m.text();
+      (a.S || function () {})(u);
+    }
+  } catch (m) {}
+}
+// 请求描述符构造函数，用于构建下载捕获对象。
+function T() {
+  this["1"] = "GET";
+  this["2"] = "";
+  this["3"] = "";
+  this["4"] = "";
+  this["5"] = "";
+  this["6"] = "normal";
+  this["7"] = 0;
+  this["8"] = "";
+  this["9"] = "";
+  this["10"] = "";
+  this.cookies = this["11"] = "";
+  this.postData = null;
+}
+// 扩展的主后台控制器。初始化监听器和上下文菜单状态。
 function U() {
-    var a = this.constructor.prototype, b; for (b in a) this[b] = a[b].bind(this); this.H = {}; this.h = {}; this.m = {}; this.fa = 1; this.u = ""; this.C = !1; chrome.contextMenus.removeAll(); chrome.contextMenus.create({ title: "Download", id: "NDM_CtxMenu", contexts: ["link", "image"] }); chrome.contextMenus.create({ id: "NDM_BlockSite", title: "Block downloads", contexts: ["all"] }); this.j(chrome.contextMenus.onClicked, this.W); this.j(chrome.downloads.onCreated, this.X); this.j(chrome.runtime.onConnect, this.Z); this.j(chrome.webRequest.onBeforeRequest, this.T, {
-        urls: ["http://*/*", "https://*/*", "ftp://*/*"],
-        types: w
-    }, ["requestBody"]); this.j(chrome.webRequest.onBeforeSendHeaders, this.U, { urls: ["https://*/*", "http://*/*"], types: w }, ["requestHeaders"]); this.j(chrome.webRequest.onHeadersReceived, this.V, { urls: ["<all_urls>"], types: w }, ["responseHeaders"]); this.j(chrome.webRequest.onCompleted, this.N, { urls: ["<all_urls>"] }); this.j(chrome.webRequest.onErrorOccurred, this.N, { urls: ["<all_urls>"] }); this.j(chrome.webNavigation.onHistoryStateUpdated, this.Y); chrome.action.onClicked.addListener(this.M); this.v = !1; chrome.action.setBadgeBackgroundColor({ color: "#FF3333" });
-    this.M(); var c = this; this.F = !0; chrome.storage.local.get(["ShowMediaPanel"], function (d) { -1 == d.ShowMediaPanel && (c.F = !1) }); this.i = this.G = null; this.D = !1; this.L()
-} var V = U.prototype; V.M = function () { var a = (this.v = !this.v) ? "" : "Off"; chrome.action.setTitle({ title: this.v ? "" : "Download catcher is Off\r\nClick to toggle catching" }); chrome.action.setBadgeText({ text: a }) }; V.Y = function (a) { var b = this.h[[a.tabId, a.frameId]]; b && b["2"] != a.url && (b.postMessage([11, a.url]), b["2"] = a.url) };
-V.X = function (a) {
-    // 检查白名单
-    if (tempWhitelist.has(a.url) || tempWhitelist.has(a.finalUrl)) {
-        // 若匹配，从白名单移除并放行（不取消）
-        tempWhitelist.delete(a.url);
-        tempWhitelist.delete(a.finalUrl);
-        return;
-    }
-    // Added early block check for downloads
-    if (isURLBlocked(a.url, a.referrer) || isURLBlocked(a.finalUrl, a.referrer)) {
-        return;
-    }
-    h || !this.v ? this.u = "" : this.u != a.finalUrl && this.u != a.url ? this.u = "" : (this.u = "", chrome.downloads.cancel(a.id), chrome.downloads.erase({ id: a.id }))
+  var a = this.constructor.prototype,
+    b;
+  for (b in a) this[b] = a[b].bind(this);
+  this.H = {};
+  this.h = {};
+  this.m = {};
+  this.fa = 1;
+  this.u = "";
+  this.C = !1;
+  chrome.contextMenus.removeAll();
+  chrome.contextMenus.create({
+    title: "Download",
+    id: "NDM_CtxMenu",
+    contexts: ["link", "image"],
+  });
+  chrome.contextMenus.create({
+    id: "NDM_BlockSite",
+    title: "Block downloads",
+    contexts: ["all"],
+  });
+  this.j(chrome.contextMenus.onClicked, this.W);
+  this.j(chrome.downloads.onCreated, this.X);
+  this.j(chrome.runtime.onConnect, this.Z);
+  this.j(
+    chrome.webRequest.onBeforeSendHeaders,
+    this.U,
+    { urls: ["https://*/*", "http://*/*"], types: w },
+    ["requestHeaders"],
+  );
+  this.j(
+    chrome.webRequest.onHeadersReceived,
+    this.V,
+    { urls: ["<all_urls>"], types: w },
+    ["responseHeaders"],
+  );
+  this.j(chrome.webRequest.onCompleted, this.N, { urls: ["<all_urls>"] });
+  this.j(chrome.webRequest.onErrorOccurred, this.N, { urls: ["<all_urls>"] });
+  this.j(chrome.webNavigation.onHistoryStateUpdated, this.Y);
+  chrome.action.onClicked.addListener(this.M);
+  this.v = !0;
+  chrome.action.setBadgeBackgroundColor({ color: "#FF3333" });
+  var c = this;
+  this.F = !0;
+  chrome.storage.local.get(
+    ["ShowMediaPanel", "ndmCatchEnabled"],
+    function (d) {
+      -1 == d.ShowMediaPanel && (c.F = !1);
+      if (typeof d.ndmCatchEnabled === "boolean") {
+        c.v = d.ndmCatchEnabled;
+      }
+      chrome.action.setTitle({
+        title: c.v ? "" : "Download catcher is Off\r\nClick to toggle catching",
+      });
+      chrome.action.setBadgeText({ text: c.v ? "" : "Off" });
+    },
+  );
+  this.i = this.G = null;
+  this.D = !1;
+  this.L();
+}
+var V = U.prototype;
+
+// 用户点击工具栏按钮时切换扩展图标徽章和标题。
+V.M = function () {
+  var a = (this.v = !this.v) ? "" : "Off";
+  chrome.action.setTitle({
+    title: this.v ? "" : "Download catcher is Off\r\nClick to toggle catching",
+  });
+  chrome.action.setBadgeText({ text: a });
+  chrome.storage.local.set({ ndmCatchEnabled: this.v });
 };
+// 安全发送消息到内容脚本端口，避免 bfcache / 断开连接端口导致未捕获异常。
+V.sendToPort = function (port, message) {
+  if (!port) return;
+  try {
+    port.postMessage(message);
+  } catch (e) {
+    console.warn("NDM: failed to postMessage to port, removing stale port", e, message);
+    if (port.id) delete this.H[port.id];
+    for (var key in this.h) if (this.h[key] === port) delete this.h[key];
+  }
+};
+
+// 通知已连接的内容脚本标签页/框架 URL 已更改。
+V.Y = function (a) {
+  var b = this.h[[a.tabId, a.frameId]];
+  if (b && b["2"] != a.url) {
+    this.sendToPort(b, [11, a.url]);
+    b["2"] = a.url;
+  }
+};
+
+// 处理新创建的下载，在下载捕获器激活时取消这些下载。
+V.X = function (a) {
+  //console.log(count++ + " - downloads.onCreated event:", a);
+  //console.log("NDM DEBUG: downloads.onCreated - processing ->", a.url || a.finalUrl);
+  // blockedHosts decision now occurs in ct.js content script.
+  //console.log("NDM DEBUG: downloads.onCreated - proceeding ->", this);
+  h || !this.v
+    ? (this.u = "")
+    : this.u != a.finalUrl && this.u != a.url
+      ? (this.u = "")
+      : ((this.u = ""),
+        chrome.downloads.cancel(a.id),
+        chrome.downloads.erase({ id: a.id }));
+};
+// 通过 websocket 将清理后的下载请求详情发送给 Neat Download Manager。
 V.I = async function (a) {
-    if (this.D) {
-        var b = "1:" + a["1"] + "\r\n"; b += "2:" + a["2"] + "\r\n"; a["3"] && (b += "3:" + a["3"] + "\r\n"); b += "6:" + (a["6"] || "normal") + "\r\n"; a["4"] && (b += "4:" + a["4"] + "\r\n"); if (a.pageUrl) { var c = a.pageUrl, d = ""; c &&= c.trim(); c && (d = (new URL(c)).origin); b += "Origin: " + d + "\r\n" } if (a.pageUrl) { if (c = a.pageUrl) d = c.lastIndexOf("#"), c = 0 > d || d < c.indexOf("?") ? c : c.substr(0, d); b += "Referer: " + c + "\r\n" } a["5"] && (b += "5:" + a["5"] + "\r\n"); a.cookies && (b += "Cookie: " + a.cookies + "\r\n"); a["10"] && (b += "Content-Type: " + a["10"] +
-            "\r\n"); a["11"] && (b += "Content-Disposition: " + a["11"] + "\r\n"); a["9"] && (b += "9:" + a["9"] + "\r\n"); for (var e in a) N(e.toLowerCase(), "x-") && (b += e + ": " + a[e] + "\r\n"); "POST" == a["1"] && (a["7"] && (b += "7:" + a["7"] + "\r\n"), a["8"] && (b += "8:" + a["8"] + "\r\n"), b = a.postData ? b + ("__0NeatPostData9__:" + a.postData) : b + "Content-Length: 0\r\n"); if (!(118784 < b.length)) if (a["3"]) this.G.send(b), this.i = null; else if ("POST" == a["1"] || !this.C || a["7"] && a["8"]) "POST" != a["1"] && this.C && (b += "8:" + a["8"] + "\r\n", b += "7:" + a["7"] + "\r\n"), this.G.send(b),
-                this.i = null; else try { const f = await fetch(a["2"], { method: "HEAD", credentials: "include" }); f.ok && (a["8"] = a["8"] || f.headers.get("content-type") || "", a["7"] = a["7"] || f.headers.get("Content-Length") || 0, b += "8:" + a["8"] + "\r\n", b += "7:" + a["7"] + "\r\n", this.G.send(b), this.i = null) } catch (f) { }
-    } else this.i = a, this.L()
-}; V.L = function () { var a = new WebSocket("ws://127.0.0.1:10007/download", "neatextension.v1"); a.onopen = this.ea; a.onclose = this.ba; a.onmessage = this.da; a.onerror = this.ca; this.G = a };
-V.ea = function () { this.D = !0; this.i && this.I(this.i) }; V.ba = function () { this.D = !1; this.i = null }; V.da = function (a) { a = a.data; "waiting" == a ? this.C = !0 : "nowaiting" == a ? this.C = !1 : !P(a, "Version") && N(a, "ShowPanelChrome") && (a = "1" == a.split("=")[1], a != this.F && (this.F = a, chrome.storage.local.set({ ka: a ? 1 : -1 }, function () { }), this.ga([13, a]))) }; V.ca = function () { this.D = !1; if (this.i) { var a = this; chrome.tabs.query({ currentWindow: !0, active: !0 }, function (b) { b && b.length && (b = a.h[[b[0].id, 0]]) && b.postMessage([15]) }) } this.i = null };
-V.J = function (a) { if (this.i) { var b = ""; if (a && 0 < a.length) for (var c = 0; c < a.length; c++)b += a[c].name + "=" + a[c].value + (c < a.length - 1 ? "; " : ""); b = b.trim(); this.i.cookies = b; this.I(this.i) } }; V.W = function (a, b) { if (a.menuItemId === "NDM_BlockSite") return; var c = Q(a.linkUrl); !c || "ftp" != c && "http" != c && "https" != c || "ftp" == c && !G(a.linkUrl) || (c = new T, c["2"] = a.linkUrl || a.srcUrl, c.pageUrl = a.pageUrl, c["4"] = b && b.title || "", b && b.url && (c["5"] = b.url), !c["5"] && (c["5"] = a.pageUrl), this.i = c, chrome.cookies.getAll({ url: c["2"] }, this.J)) }; function W(a) { this.h = a } var X = W.prototype;
-X.j = function (a) { var b = ""; if (!a) return b; if ((a = a.split(",")) && a.length) for (var c = 0; c < a.length; c++) { var d = a[c].split("="); d && 2 == d.length && ("BANDWIDTH" == d[0].toString().trim() && (b += parseInt(parseInt(d[1]) / 1024) + " Kbps "), "RESOLUTION" == d[0].toString().trim() && (b += d[1] + " ")) } return b.trim() };
-X.i = function (a, b) {
-    var c = [], d = 0, e = "", f = this; b = b.split(/[\r\n]+/); if (0 != b.length && "#EXTM3U" == b[0].trim()) {
-        for (var g = !1, m = !1, u = !1, n = "", p = RegExp("^#(EXT[^\\s:]+)(?::(.*))"), r = 1; r < b.length; r++) { var k = b[r].trim(); k && ("#" == k[0] ? 0 == k.indexOf("#EXT") && (k = p.exec(k)) && (g || (g = "EXTINF" == k[1]) && (n = k[2]), m || (m = "EXT-X-STREAM-INF" == k[1]) && (n = k[2]), u ||= "EXT-X-BYTERANGE" == k[1]) : (g && (d += parseFloat(n), g = !1), m && (c.push({ 2: (new URL(k, a["2"])).href, tags: n }), m = !1), u && !e && (e = (new URL(k, a["2"])).href))) } if (e) {
-            b = ""; d && (60 < d &&
-                (b += parseInt(d / 60) + " min "), b += parseInt(d % 60) && parseInt(d % 60) + " sec"); var l = { 6: "media", fEx: "ts", 4: "TS File " + b, fDu: b }; l = M(l, { 1: a["1"], 2: e, tabId: a.tabId, frameId: a.frameId, fS: a["7"], fileName: a.fileName }); Y(a, l); "POST" == l["1"] && S(a, l); setTimeout(function () { f.h.A(l) }, 2500)
-        } else c.length ? setTimeout(function () { for (var x = 0; x < c.length; x++)f.h.A(M({ tabId: a.tabId, frameId: a.frameId }, { 1: "GET", 2: c[x]["2"], 6: "hls", fEx: "ts", 4: "TS File " + f.j(c[x].tags) })) }, 2500) : 0 < d && (b = "", 60 < d && (b += parseInt(d / 60) + " min "), b += parseInt(d %
-            60) && parseInt(d % 60) + " sec", l = { 6: "hls", fEx: "ts", 4: "TS File " + b, fDu: b }, l = M(l, { 1: a["1"], 2: a["2"], tabId: a.tabId, frameId: a.frameId, fS: a["7"], fileName: a.fileName }), Y(a, l), "POST" == l["1"] && S(a, l), setTimeout(function () { f.h.A(l) }, 2500))
+  if (this.D) {
+    var b = "1:" + a["1"] + "\r\n";
+    b += "2:" + a["2"] + "\r\n";
+    a["3"] && (b += "3:" + a["3"] + "\r\n");
+    b += "6:" + (a["6"] || "normal") + "\r\n";
+    a["4"] && (b += "4:" + a["4"] + "\r\n");
+    if (a.pageUrl) {
+      var c = a.pageUrl,
+        d = "";
+      c &&= c.trim();
+      c && (d = new URL(c).origin);
+      b += "Origin: " + d + "\r\n";
     }
-}; V.A = function (a) { var b = this.h[[a.tabId, a.frameId]]; if (!b && (b = this.h[[a.tabId, 0]], !b)) return; var c = a["2"], d = 0, e; var f = 0; for (e = c.length; f < e; f++) { var g = c.charCodeAt(f); d = (d << 5) - d + g; d |= 0 } a.id = d; b.postMessage([1, a, b["2"]]) }; V.N = function (a) { delete this.m[a.requestId] };
+    if (a.pageUrl) {
+      if ((c = a.pageUrl))
+        ((d = c.lastIndexOf("#")),
+          (c = 0 > d || d < c.indexOf("?") ? c : c.substr(0, d)));
+      b += "Referer: " + c + "\r\n";
+    }
+    a["5"] && (b += "5:" + a["5"] + "\r\n");
+    a.cookies && (b += "Cookie: " + a.cookies + "\r\n");
+    a["10"] && (b += "Content-Type: " + a["10"] + "\r\n");
+    a["11"] && (b += "Content-Disposition: " + a["11"] + "\r\n");
+    a["9"] && (b += "9:" + a["9"] + "\r\n");
+    for (var e in a)
+      N(e.toLowerCase(), "x-") && (b += e + ": " + a[e] + "\r\n");
+    "POST" == a["1"] &&
+      (a["7"] && (b += "7:" + a["7"] + "\r\n"),
+      a["8"] && (b += "8:" + a["8"] + "\r\n"),
+      (b = a.postData
+        ? b + ("__0NeatPostData9__:" + a.postData)
+        : b + "Content-Length: 0\r\n"));
+    if (!(118784 < b.length))
+      if (a["3"]) (this.G.send(b), (this.i = null));
+      else if ("POST" == a["1"] || !this.C || (a["7"] && a["8"]))
+        ("POST" != a["1"] &&
+          this.C &&
+          ((b += "8:" + a["8"] + "\r\n"), (b += "7:" + a["7"] + "\r\n")),
+          this.G.send(b),
+          (this.i = null));
+      else
+        try {
+          const f = await fetch(a["2"], {
+            method: "HEAD",
+            credentials: "include",
+          });
+          f.ok &&
+            ((a["8"] = a["8"] || f.headers.get("content-type") || ""),
+            (a["7"] = a["7"] || f.headers.get("Content-Length") || 0),
+            (b += "8:" + a["8"] + "\r\n"),
+            (b += "7:" + a["7"] + "\r\n"),
+            this.G.send(b),
+            (this.i = null));
+        } catch (f) {}
+  } else ((this.i = a), this.L());
+};
+// 创建并初始化到桌面 NDM 应用的持久 websocket 连接。
+V.L = function () {
+  var a = new WebSocket("ws://127.0.0.1:10007/download", "neatextension.v1");
+  a.onopen = this.ea;
+  a.onclose = this.ba;
+  a.onmessage = this.da;
+  a.onerror = this.ca;
+  this.G = a;
+};
+// websocket 打开回调：标记 socket 就绪并发送任何排队请求。
+V.ea = function () {
+  this.D = !0;
+  this.i && this.I(this.i);
+};
+
+// websocket 关闭回调：标记 socket 已断开。
+V.ba = function () {
+  this.D = !1;
+  this.i = null;
+};
+// websocket 消息处理器：处理 NDM 状态事件。
+V.da = function (a) {
+  a = a.data;
+  "waiting" == a
+    ? (this.C = !0)
+    : "nowaiting" == a
+      ? (this.C = !1)
+      : !P(a, "Version") &&
+        N(a, "ShowPanelChrome") &&
+        ((a = "1" == a.split("=")[1]),
+        a != this.F &&
+          ((this.F = a),
+          chrome.storage.local.set({ ka: a ? 1 : -1 }, function () {}),
+          this.ga([13, a])));
+};
+// websocket 错误回调：清除排队请求并通知活动标签页。
+V.ca = function () {
+  this.D = !1;
+  if (this.i) {
+    var a = this;
+    chrome.tabs.query({ currentWindow: !0, active: !0 }, function (b) {
+      b && b.length && (b = a.h[[b[0].id, 0]]) && a.sendToPort(b, [15]);
+    });
+  }
+  this.i = null;
+};
+
+// chrome.cookies.getAll 回调：将 cookies 附加到待发送请求并发送它。
+V.J = function (a) {
+  if (this.i) {
+    var b = "";
+    if (a && 0 < a.length)
+      for (var c = 0; c < a.length; c++)
+        b += a[c].name + "=" + a[c].value + (c < a.length - 1 ? "; " : "");
+    b = b.trim();
+    this.i.cookies = b;
+    this.I(this.i);
+  }
+};
+// 处理上下文菜单“Download”点击并创建下载请求对象。
+V.W = function (a, b) {
+  if (a.menuItemId === "NDM_BlockSite") return;
+
+  var url = a.linkUrl || a.srcUrl;
+  if (!url) return;
+
+  // 如果扩展关闭或当前 host 被阻止，则直接触发浏览器原生下载。
+  if (!this.v || isURLBlocked(url, a.pageUrl || a.linkUrl)) {
+    chrome.downloads.download({ url: url, saveAs: false }, function (downloadId) {
+      if (chrome.runtime.lastError) {
+        console.warn("NDM fallback download failed:", chrome.runtime.lastError.message);
+      }
+    });
+    return;
+  }
+
+  var c = Q(url);
+  !c ||
+    ("ftp" != c && "http" != c && "https" != c) ||
+    ("ftp" == c && !G(url)) ||
+    ((c = new T()),
+    (c["2"] = url),
+    (c.pageUrl = a.pageUrl),
+    (c["4"] = (b && b.title) || ""),
+    b && b.url && (c["5"] = b.url),
+    !c["5"] && (c["5"] = a.pageUrl),
+    (this.i = c),
+    chrome.cookies.getAll({ url: c["2"] }, this.J)
+  );
+};
+// 帮助对象，用于处理 HLS/媒体流解析和下载条目创建。
+function W(a) {
+  this.h = a;
+}
+var X = W.prototype;
+// 将 HLS EXT-X-STREAM-INF 带宽/分辨率字符串解析为可读标签。
+X.j = function (a) {
+  var b = "";
+  if (!a) return b;
+  if ((a = a.split(",")) && a.length)
+    for (var c = 0; c < a.length; c++) {
+      var d = a[c].split("=");
+      d &&
+        2 == d.length &&
+        ("BANDWIDTH" == d[0].toString().trim() &&
+          (b += parseInt(parseInt(d[1]) / 1024) + " Kbps "),
+        "RESOLUTION" == d[0].toString().trim() && (b += d[1] + " "));
+    }
+  return b.trim();
+};
+// 解析 M3U8 播放列表内容并为分段或流变体创建下载条目。
+X.i = function (a, b) {
+  var c = [],
+    d = 0,
+    e = "",
+    f = this;
+  b = b.split(/[\r\n]+/);
+  if (0 != b.length && "#EXTM3U" == b[0].trim()) {
+    for (
+      var g = !1,
+        m = !1,
+        u = !1,
+        n = "",
+        p = RegExp("^#(EXT[^\\s:]+)(?::(.*))"),
+        r = 1;
+      r < b.length;
+      r++
+    ) {
+      var k = b[r].trim();
+      k &&
+        ("#" == k[0]
+          ? 0 == k.indexOf("#EXT") &&
+            (k = p.exec(k)) &&
+            (g || ((g = "EXTINF" == k[1]) && (n = k[2])),
+            m || ((m = "EXT-X-STREAM-INF" == k[1]) && (n = k[2])),
+            (u ||= "EXT-X-BYTERANGE" == k[1]))
+          : (g && ((d += parseFloat(n)), (g = !1)),
+            m && (c.push({ 2: new URL(k, a["2"]).href, tags: n }), (m = !1)),
+            u && !e && (e = new URL(k, a["2"]).href)));
+    }
+    if (e) {
+      b = "";
+      d &&
+        (60 < d && (b += parseInt(d / 60) + " min "),
+        (b += parseInt(d % 60) && parseInt(d % 60) + " sec"));
+      var l = { 6: "media", fEx: "ts", 4: "TS File " + b, fDu: b };
+      l = M(l, {
+        1: a["1"],
+        2: e,
+        tabId: a.tabId,
+        frameId: a.frameId,
+        fS: a["7"],
+        fileName: a.fileName,
+      });
+      Y(a, l);
+      "POST" == l["1"] && S(a, l);
+      setTimeout(function () {
+        f.h.A(l);
+      }, 2500);
+    } else
+      c.length
+        ? setTimeout(function () {
+            for (var x = 0; x < c.length; x++)
+              f.h.A(
+                M(
+                  { tabId: a.tabId, frameId: a.frameId },
+                  {
+                    1: "GET",
+                    2: c[x]["2"],
+                    6: "hls",
+                    fEx: "ts",
+                    4: "TS File " + f.j(c[x].tags),
+                  },
+                ),
+              );
+          }, 2500)
+        : 0 < d &&
+          ((b = ""),
+          60 < d && (b += parseInt(d / 60) + " min "),
+          (b += parseInt(d % 60) && parseInt(d % 60) + " sec"),
+          (l = { 6: "hls", fEx: "ts", 4: "TS File " + b, fDu: b }),
+          (l = M(l, {
+            1: a["1"],
+            2: a["2"],
+            tabId: a.tabId,
+            frameId: a.frameId,
+            fS: a["7"],
+            fileName: a.fileName,
+          })),
+          Y(a, l),
+          "POST" == l["1"] && S(a, l),
+          setTimeout(function () {
+            f.h.A(l);
+          }, 2500));
+  }
+};
+// 根据标签页/框架将解析后的下载条目发送到正确的内容脚本。
+V.A = function (a) {
+  var b = this.h[[a.tabId, a.frameId]];
+  if (!b && ((b = this.h[[a.tabId, 0]]), !b)) return;
+  var c = a["2"],
+    d = 0,
+    e;
+  var f = 0;
+  for (e = c.length; f < e; f++) {
+    var g = c.charCodeAt(f);
+    d = (d << 5) - d + g;
+    d |= 0;
+  }
+  a.id = d;
+  this.sendToPort(b, [1, a, b["2"]]);
+};
+// 当 webRequest 完成或出错时，移除存储的请求元数据。
+V.N = function (a) {
+  delete this.m[a.requestId];
+};
+
+// 将 webRequest requestBody 的原始字节或 formData 转换为序列化字符串。
 function fa(a, b) {
-    if (!a) return null; var c = a.raw; if (c) { a = ""; for (b = 0; b < c.length; b++) { var d = c[b].bytes; if (!d) return null; d = new Uint8Array(d); for (var e = d.length, f = 0; f < e; f++)a += String.fromCharCode(d[f]) } return a } c = a.formData; if (!c) return null; e = F(b); a = []; e &&= e.toLowerCase(); if ("application/x-www-form-urlencoded" == e) { for (d in c) for (e = c[d], d = d.split(" ").map(encodeURIComponent).join("+"), b = 0; b < e.length; b++)a.length && a.push("&"), a.push(d, "=", e[b].split(" ").map(encodeURIComponent).join("+")); return a.join("") } if ("multipart/form-data" ==
-        e) { (f = Z(b, "boundary")) || (f = "----WebKitFormBoundary" + Math.random().toString(36).substr(2)); for (d in c) for (e = c[d], b = 0; b < e.length; b++)a.push("--", f, '\r\nContent-Disposition: form-data; name="', d, '"\r\n\r\n', e[b], "\r\n"); a.push("--", f, "--\r\n"); return a.join("") } return null
+  if (!a) return null;
+  var c = a.raw;
+  if (c) {
+    a = "";
+    for (b = 0; b < c.length; b++) {
+      var d = c[b].bytes;
+      if (!d) return null;
+      d = new Uint8Array(d);
+      for (var e = d.length, f = 0; f < e; f++) a += String.fromCharCode(d[f]);
+    }
+    return a;
+  }
+  c = a.formData;
+  if (!c) return null;
+  e = F(b);
+  a = [];
+  e &&= e.toLowerCase();
+  if ("application/x-www-form-urlencoded" == e) {
+    for (d in c)
+      for (
+        e = c[d], d = d.split(" ").map(encodeURIComponent).join("+"), b = 0;
+        b < e.length;
+        b++
+      )
+        (a.length && a.push("&"),
+          a.push(d, "=", e[b].split(" ").map(encodeURIComponent).join("+")));
+    return a.join("");
+  }
+  if ("multipart/form-data" == e) {
+    (f = Z(b, "boundary")) ||
+      (f = "----WebKitFormBoundary" + Math.random().toString(36).substr(2));
+    for (d in c)
+      for (e = c[d], b = 0; b < e.length; b++)
+        a.push(
+          "--",
+          f,
+          '\r\nContent-Disposition: form-data; name="',
+          d,
+          '"\r\n\r\n',
+          e[b],
+          "\r\n",
+        );
+    a.push("--", f, "--\r\n");
+    return a.join("");
+  }
+  return null;
 }
 V.V = function (a) {
-    if (tempWhitelist.has(a.url)) {
-        tempWhitelist.delete(a.url);
-        return;
-    }
-    if (isURLBlocked(a.url, a.initiator)) return; var b, c = a.requestId, d = this; if (b = this.m[c]) {
-        var e = a.url, f = a.type, g = 0 <= z.indexOf(f), m = a.method.toUpperCase(), u = Q(e); if (!u || "http" != u && "https" != u || "GET" != m && "POST" != m) delete this.m[c]; else {
-            b.B = a.responseHeaders; var n = L(b.B, "Content-Type"), p = F(n).toLowerCase(); if ("image" == f && p && N(p.toLowerCase(), "image/")) delete this.m[c]; else {
-                var r = L(b.B, "Content-Disposition"), k = "attachment" == F(r).toLowerCase(); a = parseInt(a.statusLine.split(" ", 2).pop()) || 0; b.ha = 0 <= aa.indexOf(a); if (!b.ha) {
-                    if (200 == a ||
-                        206 == a) {
-                        a = L(b.B, "Content-Length"); var l = L(b.B, "Content-Range"), x = null; l && (l = q.exec(l)) && (a = l[1]); a && (x = parseInt(a)); if (0 !== x) if (b["2"] = e, b["8"] = n, b["7"] = x, b.type = f, b.protocol = u, b["1"] = m, b.R = O(f, "_frame"), f = new URL(e), e = f.hostname, f = f.pathname, (m = f.split("/").pop().trim()) && (m = m.split("?").shift().trim()), b.l = m || "", b.s = K(b.l), b.K = Z(r, "filename") || Z(n, "name"), b.P = b.K && K(b.K) || "", n = p ? E[p] : !1, b.O = (n ? n.split("|").shift() : "").toLowerCase(), b.g = b.O || b.P || b.s || "", b.fileName = b.K || b.l || "", b.fileName && (n = b.fileName.lastIndexOf("."),
-                            -1 < n && (b.fileName = b.fileName.substr(0, n).trim())), b.fileName && b.g && (b.fileName += "." + b.g), !p && b.g && (p = ea(b.g)), n = "main_frame" == b.type && B.test(b.g) && !C.test(b.g), r = ["js", "txt", "dict"], r = -1 < r.indexOf(b.g) || -1 < r.indexOf(b.s), P(b.l.toLowerCase(), "manif") || P(b.l.toLowerCase(), "favicon.ico") || P(b.l.toLowerCase(), "pem.msg") || O(b.l.toLowerCase(), ".wasm") || P(b.l.toLowerCase(), ".json") || P(b.O.toLowerCase(), "json") || P(b.P.toLowerCase(), "json") || O(b.l.toLowerCase(), ".dict") || !(n || "other" == b.type && B.test(b.g) ||
-                                (b.R || !g) && da.test(b.g) || (b.R || "other" == b.type) && (k && !r || ba.test(p) || b.g && !B.test(b.g) && !ca.test(b.g)))) {
-                            k = "vtt" == b.g.toLowerCase() || "vtt" == b.s.toLowerCase() || "srt" == b.g.toLowerCase() || "srt" == b.s.toLowerCase(); var H = null; "m3u8" == b.g.toLowerCase() || "m3u8" == b.s.toLowerCase() ? H = new W(this) : k || "POST" == b["1"] || P(e.toLowerCase(), "vimeo") || P(e.toLowerCase(), "youtube") || P(e.toLowerCase(), "google") || "txt" != b.g.toLowerCase() && "js" != b.g.toLowerCase() || "xmlhttprequest" != b.type || b["7"] && 307200 < b["7"] || (H = new W(this));
-                            if (H) R({ 2: b["2"], S: function (t) { H.i(M({}, b), t) } }, M({}, b)); else if (g && "player.vimeo.com" == e && N(f, "/video/") && "application/json" == p) R({ 2: b["2"], S: function (t) { var y = null; try { y = JSON.parse(t) } catch (D) { } if (y) { var I = y.request.files.progressive; I && setTimeout(function () { for (var D = 0; D < I.length; D++)d.A({ 1: "GET", 2: I[D].url, 6: "media", tabId: b.tabId, frameId: b.frameId, fEx: "mp4", 4: "MP4 File " + I[D].quality }) }, 2500) } } }, b); else if ((g || k) && (B.test(b.g) || B.test(b.s)) && !C.test(b.g) && (!b["7"] || 512E3 < b["7"] || k) && !("ASF" ==
-                                b.g && 256E4 >= b["7"]) && "DCLK-AdSvr" != L(b.B, "Server")) { var J = { 2: b["2"], 6: "media", 1: b["1"], tabId: b.tabId, frameId: b.frameId, fEx: B.test(b.g) ? b.g : b.s, 7: b["7"], 8: b["8"], fS: b["7"], fileName: b.fileName }; "POST" == J["1"] && S(b, J); Y(b, J); setTimeout(function () { d.A(J) }, 2E3) }
-                        } else if (h || !this.v) this.u = ""; else {
-                            this.u = b["2"]; g = d.h[[b.tabId, b.frameId]]; p = d.h[[b.tabId, 0]]; var v = M(new T, { 2: b["2"], 1: b["1"], 4: p && p["4"] || g && g["4"], 5: p && p["2"] || g && g["2"], 7: b["7"], 8: b["8"], pageUrl: g && g["2"] || b["2"] }); chrome.tabs.query({
-                                active: !0,
-                                currentWindow: !0
-                            }, function (t) { if (t && t.length && (b["2"] == t[0].pendingUrl || b["2"] == t[0].url) && !v["5"] && t[0].openerTabId) { var y = d.h[[t[0].openerTabId, 0]]; v["5"] = y && y["2"]; v["4"] = y && y["4"]; B.test(b.g) && (chrome.tabs.remove(t[0].id), v["6"] = "media") } }); "POST" == v["1"] && S(b, v); Y(b, v); d.i = v; chrome.cookies.getAll({ url: v["2"] }, d.J)
+  //console.log("NDM DEBUG: onHeadersReceived event:", a);
+  // blockedHosts decision now occurs in ct.js content script.
+  var b,
+    c = a.requestId,
+    d = this;
+  if ((b = this.m[c])) {
+    var e = a.url,
+      f = a.type,
+      g = 0 <= z.indexOf(f),
+      m = a.method.toUpperCase(),
+      u = Q(e);
+    if (!u || ("http" != u && "https" != u) || ("GET" != m && "POST" != m))
+      delete this.m[c];
+    else {
+      b.B = a.responseHeaders;
+      var n = L(b.B, "Content-Type"),
+        p = F(n).toLowerCase();
+      if ("image" == f && p && N(p.toLowerCase(), "image/")) delete this.m[c];
+      else {
+        var r = L(b.B, "Content-Disposition"),
+          k = "attachment" == F(r).toLowerCase();
+        a = parseInt(a.statusLine.split(" ", 2).pop()) || 0;
+        b.ha = 0 <= aa.indexOf(a);
+        if (!b.ha) {
+          if (200 == a || 206 == a) {
+            a = L(b.B, "Content-Length");
+            var l = L(b.B, "Content-Range"),
+              x = null;
+            l && (l = q.exec(l)) && (a = l[1]);
+            a && (x = parseInt(a));
+            if (0 !== x)
+              if (
+                ((b["2"] = e),
+                (b["8"] = n),
+                (b["7"] = x),
+                (b.type = f),
+                (b.protocol = u),
+                (b["1"] = m),
+                (b.R = O(f, "_frame")),
+                (f = new URL(e)),
+                (e = f.hostname),
+                (f = f.pathname),
+                (m = f.split("/").pop().trim()) &&
+                  (m = m.split("?").shift().trim()),
+                (b.l = m || ""),
+                (b.s = K(b.l)),
+                (b.K = Z(r, "filename") || Z(n, "name")),
+                (b.P = (b.K && K(b.K)) || ""),
+                (n = p ? E[p] : !1),
+                (b.O = (n ? n.split("|").shift() : "").toLowerCase()),
+                (b.g = b.O || b.P || b.s || ""),
+                (b.fileName = b.K || b.l || ""),
+                b.fileName &&
+                  ((n = b.fileName.lastIndexOf(".")),
+                  -1 < n && (b.fileName = b.fileName.substr(0, n).trim())),
+                b.fileName && b.g && (b.fileName += "." + b.g),
+                !p && b.g && (p = ea(b.g)),
+                (n = "main_frame" == b.type && B.test(b.g) && !C.test(b.g)),
+                (r = ["js", "txt", "dict"]),
+                (r = -1 < r.indexOf(b.g) || -1 < r.indexOf(b.s)),
+                P(b.l.toLowerCase(), "manif") ||
+                  P(b.l.toLowerCase(), "favicon.ico") ||
+                  P(b.l.toLowerCase(), "pem.msg") ||
+                  O(b.l.toLowerCase(), ".wasm") ||
+                  P(b.l.toLowerCase(), ".json") ||
+                  P(b.O.toLowerCase(), "json") ||
+                  P(b.P.toLowerCase(), "json") ||
+                  O(b.l.toLowerCase(), ".dict") ||
+                  !(
+                    n ||
+                    ("other" == b.type && B.test(b.g)) ||
+                    ((b.R || !g) && da.test(b.g)) ||
+                    ((b.R || "other" == b.type) &&
+                      ((k && !r) ||
+                        ba.test(p) ||
+                        (b.g && !B.test(b.g) && !ca.test(b.g))))
+                  ))
+              ) {
+                k =
+                  "vtt" == b.g.toLowerCase() ||
+                  "vtt" == b.s.toLowerCase() ||
+                  "srt" == b.g.toLowerCase() ||
+                  "srt" == b.s.toLowerCase();
+                var H = null;
+                "m3u8" == b.g.toLowerCase() || "m3u8" == b.s.toLowerCase()
+                  ? (H = new W(this))
+                  : k ||
+                    "POST" == b["1"] ||
+                    P(e.toLowerCase(), "vimeo") ||
+                    P(e.toLowerCase(), "youtube") ||
+                    P(e.toLowerCase(), "google") ||
+                    ("txt" != b.g.toLowerCase() && "js" != b.g.toLowerCase()) ||
+                    "xmlhttprequest" != b.type ||
+                    (b["7"] && 307200 < b["7"]) ||
+                    (H = new W(this));
+                if (H)
+                  R(
+                    {
+                      2: b["2"],
+                      S: function (t) {
+                        H.i(M({}, b), t);
+                      },
+                    },
+                    M({}, b),
+                  );
+                else if (
+                  g &&
+                  "player.vimeo.com" == e &&
+                  N(f, "/video/") &&
+                  "application/json" == p
+                )
+                  R(
+                    {
+                      2: b["2"],
+                      S: function (t) {
+                        var y = null;
+                        try {
+                          y = JSON.parse(t);
+                        } catch (D) {}
+                        if (y) {
+                          var I = y.request.files.progressive;
+                          I &&
+                            setTimeout(function () {
+                              for (var D = 0; D < I.length; D++)
+                                d.A({
+                                  1: "GET",
+                                  2: I[D].url,
+                                  6: "media",
+                                  tabId: b.tabId,
+                                  frameId: b.frameId,
+                                  fEx: "mp4",
+                                  4: "MP4 File " + I[D].quality,
+                                });
+                            }, 2500);
                         }
-                    } delete this.m[c]
+                      },
+                    },
+                    b,
+                  );
+                else if (
+                  (g || k) &&
+                  (B.test(b.g) || B.test(b.s)) &&
+                  !C.test(b.g) &&
+                  (!b["7"] || 512e3 < b["7"] || k) &&
+                  !("ASF" == b.g && 256e4 >= b["7"]) &&
+                  "DCLK-AdSvr" != L(b.B, "Server")
+                ) {
+                  var J = {
+                    2: b["2"],
+                    6: "media",
+                    1: b["1"],
+                    tabId: b.tabId,
+                    frameId: b.frameId,
+                    fEx: B.test(b.g) ? b.g : b.s,
+                    7: b["7"],
+                    8: b["8"],
+                    fS: b["7"],
+                    fileName: b.fileName,
+                  };
+                  "POST" == J["1"] && S(b, J);
+                  Y(b, J);
+                  setTimeout(function () {
+                    d.A(J);
+                  }, 2e3);
                 }
-            }
+              } else if (h || !this.v) this.u = "";
+              else {
+                if (b.browserDownload) {
+                  this.u = "";
+                } else {
+                  this.u = b["2"];
+                }
+                g = d.h[[b.tabId, b.frameId]];
+                p = d.h[[b.tabId, 0]];
+                var v = M(new T(), {
+                  2: b["2"],
+                  1: b["1"],
+                  4: (p && p["4"]) || (g && g["4"]),
+                  5: (p && p["2"]) || (g && g["2"]),
+                  7: b["7"],
+                  8: b["8"],
+                  pageUrl: (g && g["2"]) || b["2"],
+                });
+                if (b.browserDownload) {
+                  v["x-Download-Mode"] = "browser";
+                }
+                chrome.tabs.query(
+                  {
+                    active: !0,
+                    currentWindow: !0,
+                  },
+                  function (t) {
+                    if (
+                      t &&
+                      t.length &&
+                      (b["2"] == t[0].pendingUrl || b["2"] == t[0].url) &&
+                      !v["5"] &&
+                      t[0].openerTabId
+                    ) {
+                      var y = d.h[[t[0].openerTabId, 0]];
+                      v["5"] = y && y["2"];
+                      v["4"] = y && y["4"];
+                      B.test(b.g) &&
+                        (chrome.tabs.remove(t[0].id), (v["6"] = "media"));
+                    }
+                  },
+                );
+                "POST" == v["1"] && S(b, v);
+                Y(b, v);
+                d.i = v;
+                chrome.cookies.getAll({ url: v["2"] }, d.J);
+              }
+          }
+          delete this.m[c];
         }
+      }
     }
+  }
 };
-function S(a, b) { var c = L(a.o, "Content-Type"), d = L(a.o, "Content-Disposition"); a = fa(a.ja, c); if (!a || 1 > a.length) a = null; b.postData = a; c && (b["10"] = c.trim()); d && (b["11"] = d.trim()) } function Y(a, b) { if (a.o) for (var c = 0; c < a.o.length; c++)N(a.o[c].name.toLowerCase(), "x-") && (b[a.o[c].name] = a.o[c].value) } V.U = function (a) { if (!(0 > a.tabId || 0 > a.frameId)) { var b = this.m[a.requestId]; b && (b.o = a.requestHeaders) } };
-V.T = function (a) {
-    // 检查临时白名单：如果在白名单内，直接放行（不记录、不取消）
-    if (tempWhitelist.has(a.url)) {
-        // 可选：移除已匹配的条目，避免后续重复使用（若想仅放行一次）
-        tempWhitelist.delete(a.url);
-        return; // 让请求正常进行
+// 提取 POST 正文数据和头部值到下载描述符中。
+function S(a, b) {
+  var c = L(a.o, "Content-Type"),
+    d = L(a.o, "Content-Disposition");
+  a = fa(a.ja, c);
+  if (!a || 1 > a.length) a = null;
+  b.postData = a;
+  c && (b["10"] = c.trim());
+  d && (b["11"] = d.trim());
+}
+// 将请求描述符中的 X- 头复制到外发的下载描述符。
+function Y(a, b) {
+  if (a.o)
+    for (var c = 0; c < a.o.length; c++)
+      N(a.o[c].name.toLowerCase(), "x-") && (b[a.o[c].name] = a.o[c].value);
+}
+
+// onBeforeSendHeaders 处理器：存储请求头以便后续下载重构。
+V.U = function (a) {
+  if (!(0 > a.tabId || 0 > a.frameId)) {
+    var b = this.m[a.requestId];
+    b && (b.o = a.requestHeaders);
+  }
+};
+// onBeforeRequest 处理器：捕获下载请求并存储元数据。
+V.T = function (a) { 
+  //console.log("NDM DEBUG: onBeforeRequest event:", a);
+  // ct.js 负责 alt/ctrl/blockedHosts 判断，bg.js 只负责处理下载请求。
+  if (!(0 > a.tabId || 0 > a.frameId)) {
+    if (isURLBlocked(a.url, a.initiator || a.documentUrl || a.originUrl)) {
+      //console.log("NDM DEBUG: skipping blocked host request:", a.url);
+      return;
     }
-    // Added early block check
-    if (isURLBlocked(a.url, a.initiator)) return ;
-    if (!(0 > a.tabId || 0 > a.frameId)) if ("ftp" == Q(a.url)) { if (G(a.url) && !h) { var b = new T, c = this.h[[a.tabId, 0]]; c && c["2"] && (b["5"] = c["2"], b.pageUrl = c["2"]); c && c["4"] && (b["4"] = c["4"]); b["2"] = a.url; this.I(b) } } else b = a.requestId, c = this.m[b] || { id: b, 2: a.url, tabId: a.tabId, frameId: a.frameId }, "POST" == a.method.toUpperCase() && (c.ja = a.requestBody), this.m[b] = c
+    if ("ftp" == Q(a.url)) {
+      if (G(a.url) && !h) {
+        var b = new T(),
+          c = this.h[[a.tabId, 0]];
+        c && c["2"] && ((b["5"] = c["2"]), (b.pageUrl = c["2"]));
+        c && c["4"] && (b["4"] = c["4"]);
+        b["2"] = a.url;
+        this.I(b);
+      }
+    } else
+      ((b = a.requestId),
+        (c = this.m[b] || {
+          id: b,
+          2: a.url,
+          tabId: a.tabId,
+          frameId: a.frameId,
+        }),
+        "POST" == a.method.toUpperCase() && (c.ja = a.requestBody),
+        (this.m[b] = c));
+  }
 };
-function Z(a, b) { if (!a) return null; b = b.toLowerCase(); a = a.split(";"); a.shift(); for (var c = 0; c < a.length; c++) { var d = a[c], e = d.indexOf("="); if (0 < e) { var f = d.substr(0, e).trim().toLowerCase(), g = "*" == f[f.length - 1]; g && (f = f.substr(0, f.length - 1).trimRight()); if (f == b) return a = d.substr(e + 1).trim(), c = a.length - 1, '"' == a[0] && '"' == a[c] && (a = a.substring(1, c)), g && (a = a.split("'", 3).pop()), unescape(a) } else if (0 > e && d.trim().toLowerCase() == b) return "" } return null } V.j = function (a) { a.addListener.apply(a, Array.prototype.slice.call(arguments).slice(1)) };
-V.Z = function (a) { var b = a.sender.tab; if (b && 0 <= b.id) { var c = a.sender.frameId, d = a.id || this.fa++, e = b.id; a.id = d; a["4"] = b.title; a.tabId = e; a.frameId = c; a.ia = 0 == c; a["2"] = a.sender.url || a.ia && b.url || null; a.onMessage.addListener(this.aa.bind(this, a)); a.onDisconnect.addListener(this.$.bind(this, a)); this.H[d] = a; this.h[[e, c]] = a; a.postMessage([3, a.id]); a.postMessage([13, this.F]); a.sender = null } };
+// 从 Content-Type 或 Content-Disposition 头部解析单个参数值。
+function Z(a, b) {
+  if (!a) return null;
+  b = b.toLowerCase();
+  a = a.split(";");
+  a.shift();
+  for (var c = 0; c < a.length; c++) {
+    var d = a[c],
+      e = d.indexOf("=");
+    if (0 < e) {
+      var f = d.substr(0, e).trim().toLowerCase(),
+        g = "*" == f[f.length - 1];
+      g && (f = f.substr(0, f.length - 1).trimRight());
+      if (f == b)
+        return (
+          (a = d.substr(e + 1).trim()),
+          (c = a.length - 1),
+          '"' == a[0] && '"' == a[c] && (a = a.substring(1, c)),
+          g && (a = a.split("'", 3).pop()),
+          unescape(a)
+        );
+    } else if (0 > e && d.trim().toLowerCase() == b) return "";
+  }
+  return null;
+}
+// 向 chrome 事件添加监听器，并将当前方法绑定到此对象。
+V.j = function (a) {
+  a.addListener.apply(a, Array.prototype.slice.call(arguments).slice(1));
+};
+
+// 处理新的内容脚本连接并注册消息/断开回调。
+V.Z = function (a) {
+  var b = a.sender.tab;
+  if (b && 0 <= b.id) {
+    var c = a.sender.frameId,
+      d = a.id || this.fa++,
+      e = b.id;
+    a.id = d;
+    a["4"] = b.title;
+    a.tabId = e;
+    a.frameId = c;
+    a.ia = 0 == c;
+    a["2"] = a.sender.url || (a.ia && b.url) || null;
+    a.onMessage.addListener(this.aa.bind(this, a));
+    a.onDisconnect.addListener(this.$.bind(this, a));
+    this.H[d] = a;
+    this.h[[e, c]] = a;
+    this.sendToPort(a, [3, a.id]);
+    this.sendToPort(a, [13, this.F]);
+    a.sender = null;
+  }
+};
+// 分发从已连接内容脚本接收的消息。
 V.aa = function (a, b) {
-    switch (b[0]) {
-        case 2: var c = b[2], d = b[3]; (a = this.H[b[1]]) && c && (a["2"] = c); a && d && (a["4"] = d); break; case 4: h = b[1]; break; case 6: c = b[1]; a = (a = a.tabId) && this.h[[a, 0]]; var e = new T; e["1"] = c["1"] || "GET"; e["2"] = c["2"]; c["3"] && (e["3"] = c["3"]); e.pageUrl = b[2]; e["4"] = b[3] || a && a["4"] || ""; e["5"] = a && a["2"] || e.pageUrl; e["9"] = b[4]; c["7"] && (e["7"] = c["7"]); c["8"] && (e["8"] = c["8"]); e["6"] = c["6"] || "media"; !c.fEx || "vtt" != c.fEx.toLowerCase() && "srt" != c.fEx.toLowerCase() || (e["6"] = "normal"); c.postData && (e.postData =
-            c.postData); c["10"] && (e["10"] = c["10"]); c["11"] && (e["11"] = c["11"]); for (d in c) N(d.toLowerCase(), "x-") && (e[d] = c[d]); this.i = e; chrome.cookies.getAll({ url: e["2"] }, this.J)
+  switch (b[0]) {
+    case 2:
+      var c = b[2],
+        d = b[3];
+      (a = this.H[b[1]]) && c && (a["2"] = c);
+      a && d && (a["4"] = d);
+      break;
+    case 4:
+      h = b[1];
+      break;
+    case 6:
+      c = b[1];
+      a = (a = a.tabId) && this.h[[a, 0]];
+      var e = new T();
+      e["1"] = c["1"] || "GET";
+      e["2"] = c["2"];
+      c["3"] && (e["3"] = c["3"]);
+      e.pageUrl = b[2];
+      e["4"] = b[3] || (a && a["4"]) || "";
+      e["5"] = (a && a["2"]) || e.pageUrl;
+      e["9"] = b[4];
+      c["7"] && (e["7"] = c["7"]);
+      c["8"] && (e["8"] = c["8"]);
+      e["6"] = c["6"] || "media";
+      !c.fEx ||
+        ("vtt" != c.fEx.toLowerCase() && "srt" != c.fEx.toLowerCase()) ||
+        (e["6"] = "normal");
+      c.postData && (e.postData = c.postData);
+      c["10"] && (e["10"] = c["10"]);
+      c["11"] && (e["11"] = c["11"]);
+      for (d in c) N(d.toLowerCase(), "x-") && (e[d] = c[d]);
+      this.i = e;
+      chrome.cookies.getAll({ url: e["2"] }, this.J);
+      break;
+  }
+};
+// 从内部映射中移除已断开连接的内容脚本。
+V.$ = function (a) {
+  for (var b in this.h) this.h[b] == a && delete this.h[b];
+  delete this.H[a.id];
+};
+
+// 向所有匹配标签页/框架键前缀的内容脚本广播消息。
+V.la = function (a, b) {
+  var c = this.h;
+  a = a.toString() + ",";
+  for (var d in c) N(d, a) && this.sendToPort(c[d], b);
+};
+// 向所有已连接的内容脚本广播消息。
+V.ga = function (a) {
+  var b = this.h,
+    c;
+  for (c in b) this.sendToPort(b[c], a);
+};
+bgInstance = new U();
+
+// 上下文菜单点击处理器，用于阻止或解除阻止当前站点。
+chrome.contextMenus.onClicked.addListener(function (info, tab) {
+  if (info.menuItemId === "NDM_BlockSite") {
+    var url = tab.url;
+    try {
+      var hostname = new URL(url).hostname;
+      if (hostname) {
+        chrome.storage.local.get(["blockedHosts"], function (result) {
+          var blockedHosts = result.blockedHosts || [];
+          var index = blockedHosts.indexOf(hostname);
+          if (index !== -1) {
+            blockedHosts.splice(index, 1);
+            //console.log("Unblocked: " + hostname);
+          } else {
+            blockedHosts.push(hostname);
+            //console.log("Blocked: " + hostname);
+          }
+          chrome.storage.local.set({ blockedHosts: blockedHosts }, function () {
+            updateContextMenu(tab.id);
+          });
+        });
+      }
+    } catch (e) {
+      console.error(e);
     }
-}; V.$ = function (a) { for (var b in this.h) this.h[b] == a && delete this.h[b]; delete this.H[a.id] }; V.la = function (a, b) { var c = this.h; a = a.toString() + ","; for (var d in c) N(d, a) && c[d].postMessage(b) }; V.ga = function (a) { var b = this.h, c; for (c in b) b[c].postMessage(a) }; new U;
-chrome.contextMenus.onClicked.addListener(function (info, tab) { if (info.menuItemId === "NDM_BlockSite") { var url = tab.url; try { var hostname = new URL(url).hostname; if (hostname) { chrome.storage.local.get(["blockedHosts"], function (result) { var blockedHosts = result.blockedHosts || []; var index = blockedHosts.indexOf(hostname); if (index !== -1) { blockedHosts.splice(index, 1); console.log("Unblocked: " + hostname); } else { blockedHosts.push(hostname); console.log("Blocked: " + hostname); } chrome.storage.local.set({ blockedHosts: blockedHosts }, function () { updateContextMenu(tab.id); }); }); } } catch (e) { console.error(e); } } });
+  }
+});

--- a/ct.js
+++ b/ct.js
@@ -727,15 +727,6 @@ if (!window.m) {
   window.neatDownloadManagerExtensionInstance = new N();
 }
 
-function isDownloadLink(target, href) {
-  if (!href) return false;
-  if (target.hasAttribute("download")) return true;
-  var extMatch = href.match(/\.([a-z0-9]{1,8})(?:[?#]|$)/i);
-  if (!extMatch) return false;
-  var ext = extMatch[1].toLowerCase();
-  return /^(zip|exe|dmg|pdf|mp4|m4a|mp3|jpg|jpeg|png|gif|svg|rar|7z|tar|gz|iso|apk|docx?|xlsx?|pptx?|txt|csv|ppt|mpg|mpeg|mkv|avi|wmv|flv|mov|webm|ogg|opus)$/i.test(ext);
-}
-
 function isBlockedHost(hostname) {
   if (!hostname || !blockedHosts || blockedHosts.length === 0) return false;
   return blockedHosts.some(function (host) {
@@ -764,7 +755,6 @@ function handleLinkClick(e) {
 
   var href = target.href;
   if (!href || !/^(https?|ftp):/i.test(href)) return;
-  if (!isDownloadLink(target, href)) return;
 
   var currentHost = window.location.hostname;
   if (isBlockedHost(currentHost)) return;

--- a/ct.js
+++ b/ct.js
@@ -1,102 +1,789 @@
-var h = chrome.runtime.getURL("img/icon16.png"), q = chrome.runtime.getURL("img/close16.png"), r = { "-1": "none", 1: "" }; function t(c) { return document.getElementById(c) } window.el = t; function u() { var c = document.location.host.toLowerCase(), e = c.length - 12; return 0 <= e && c.indexOf("facebook.com", e) == e } async function y(c) { try { const e = await fetch(c["2"], { mode: "no-cors" }); if (e.ok) { let a = await e.text(); (c.pa || function () { })(a) } } catch (e) { } }
-function B(c) { var e = 0, a; var b = 0; for (a = c.length; b < a; b++) { var d = c.charCodeAt(b); e = (e << 5) - e + d; e |= 0 } return e } function C(c) { return !c || 0 > c ? " " : 1E3 > c ? c + " Bytes" : 1E6 > c ? (c / 1024).toFixed(1) + " KB" : 1E9 > c ? (c / 1048576).toFixed(2) + " MB" : (c / 1073741824).toFixed(3) + " GB" } function D(c) { if (!c) return { left: 0, top: 0 }; try { var e = c.getBoundingClientRect(); return e ? { left: Math.round(e.left + window.pageXOffset), top: Math.round(e.top + window.pageYOffset) } : { left: 0, top: 0 } } catch (a) { return { left: 0, top: 0 } } }
-function K(c) { return c ? !c.fEx || "VTT" != c.fEx.toUpperCase() && "SRT" != c.fEx.toUpperCase() ? c["4"] || (c.fEx.toUpperCase() || "MP4") + " File  " + (C(c.fS) || c.fDu) : c.fEx.toUpperCase() + " Subtitles File " + (c.fS ? C(c.fS) : " ") : "Media File" } function L(c, e, a) { this.v = c; c.h[a] = this; this.oa = a; this.H = "neatTable" + a; this.L = "neatHCell" + a; this.g = null; this.l = e; this.i = null; this.position = { left: 0, top: 0 }; this.A = -1; this.items = []; this.O = this.N = 0; this.o = this.u = !1 } var M = L.prototype;
-M.B = function (c) { var e = Array.prototype.slice.call(arguments); e[2] = e[2].bind(this); c.addEventListener.apply(c, e.slice(1)) }; M.s = function () { this.g && (this.g.style.left = this.position.left + "px", this.g.style.top = this.position.top + "px", this.g.style.zIndex += 500) }; M.S = function (c) { this.I(!0); this.v.ia(this.items[c]) }; M.I = function (c) { if (!c || -1 != this.A) { var e = t(this.H).rows; this.A = c ? -1 : -this.A; for (c = 1; c < e.length; c++)e[c].style.display = r[this.A] } };
+var h = chrome.runtime.getURL("img/icon16.png"),
+  q = chrome.runtime.getURL("img/close16.png"),
+  r = { "-1": "none", 1: "" };
+function t(c) {
+  return document.getElementById(c);
+}
+window.el = t;
+function u() {
+  var c = document.location.host.toLowerCase(),
+    e = c.length - 12;
+  return 0 <= e && c.indexOf("facebook.com", e) == e;
+}
+async function y(c) {
+  try {
+    const e = await fetch(c["2"], { mode: "no-cors" });
+    if (e.ok) {
+      let a = await e.text();
+      (c.pa || function () {})(a);
+    }
+  } catch (e) {}
+}
+function B(c) {
+  var e = 0,
+    a;
+  var b = 0;
+  for (a = c.length; b < a; b++) {
+    var d = c.charCodeAt(b);
+    e = (e << 5) - e + d;
+    e |= 0;
+  }
+  return e;
+}
+function C(c) {
+  return !c || 0 > c
+    ? " "
+    : 1e3 > c
+      ? c + " Bytes"
+      : 1e6 > c
+        ? (c / 1024).toFixed(1) + " KB"
+        : 1e9 > c
+          ? (c / 1048576).toFixed(2) + " MB"
+          : (c / 1073741824).toFixed(3) + " GB";
+}
+function D(c) {
+  if (!c) return { left: 0, top: 0 };
+  try {
+    var e = c.getBoundingClientRect();
+    return e
+      ? {
+          left: Math.round(e.left + window.pageXOffset),
+          top: Math.round(e.top + window.pageYOffset),
+        }
+      : { left: 0, top: 0 };
+  } catch (a) {
+    return { left: 0, top: 0 };
+  }
+}
+function K(c) {
+  return c
+    ? !c.fEx || ("VTT" != c.fEx.toUpperCase() && "SRT" != c.fEx.toUpperCase())
+      ? c["4"] ||
+        (c.fEx.toUpperCase() || "MP4") + " File  " + (C(c.fS) || c.fDu)
+      : c.fEx.toUpperCase() + " Subtitles File " + (c.fS ? C(c.fS) : " ")
+    : "Media File";
+}
+function L(c, e, a) {
+  this.v = c;
+  c.h[a] = this;
+  this.oa = a;
+  this.H = "neatTable" + a;
+  this.L = "neatHCell" + a;
+  this.g = null;
+  this.l = e;
+  this.i = null;
+  this.position = { left: 0, top: 0 };
+  this.A = -1;
+  this.items = [];
+  this.O = this.N = 0;
+  this.o = this.u = !1;
+}
+var M = L.prototype;
+M.B = function (c) {
+  var e = Array.prototype.slice.call(arguments);
+  e[2] = e[2].bind(this);
+  c.addEventListener.apply(c, e.slice(1));
+};
+M.s = function () {
+  this.g &&
+    ((this.g.style.left = this.position.left + "px"),
+    (this.g.style.top = this.position.top + "px"),
+    (this.g.style.zIndex += 500));
+};
+M.S = function (c) {
+  this.I(!0);
+  this.v.ia(this.items[c]);
+};
+M.I = function (c) {
+  if (!c || -1 != this.A) {
+    var e = t(this.H).rows;
+    this.A = c ? -1 : -this.A;
+    for (c = 1; c < e.length; c++) e[c].style.display = r[this.A];
+  }
+};
 M.F = function (c) {
-    var e = this, a = t(this.H), b = this.v.K(this.items[c]); var d = a.insertRow(-1); d.cssText = "all:revert;padding:0px;margin:0px;width:100%;line-height:100% !important;height:19px !important"; d.style.display = r[e.A]; a = d.insertCell(0); a.style.cssText = "all:revert;letter-spacing:normal;line-height:100% !important;width:100%;height:19px !important;margin:0px;padding:0px;padding-left:5px;vertical-align:middle;color:black !important;cursor:default;border:dotted 1px black;background:#c9dff2 !important;direction:ltr;text-align:left;font-family:tahoma !important;font-style:normal;font-weight:bold;font-size:7pt !important";
-    b = K(b); if (0 == c && 1 == this.items.length) {
-        d = document.createElement("TABLE"); d.style.cssText = "all:revert;border-spacing:0px;border-collapse:separate;padding:0px;margin:0px;width:100%;border:solid 1px black;direction:ltr;line-height:100% !important"; var f = d.insertRow(-1); f.style.cssText = "all:revert;padding:0px;margin:0px;line-height:100% !important;height:19px !important"; var g = f.insertCell(-1); g.style.cssText = "all:revert;background:#c9dff2 !important;padding:0px;margin:0px;width:20px;height:19px !important;text-align:center;vertical-align:middle;line-height:100% !important";
-        var k = document.createElement("IMG"); k.src = h; k.onclick = function () { alert("NeatDownloadManager Video/Audio Panel.") }; g.appendChild(k); g = f.insertCell(-1); g.id = e.L; g.style.cssText = "all:revert;letter-spacing:normal;padding:0px;margin:0px;vertical-align:middle;color:black !important;cursor:default;background:#c9dff2 !important;direction:ltr;text-align:center;font-family:tahoma !important;font-style:normal;font-weight:bold;font-size:7pt !important;height:19px !important;line-height:100% !important"; g = f.insertCell(-1);
-        g.style.cssText = "all:revert;background:#c9dff2 !important;padding:0px;margin:0px;width:20px;height:19px !important;text-align:center;vertical-align:middle;line-height:100% !important"; f = document.createElement("IMG"); f.src = q; f.onclick = function () { e.g.style.display = "none" }; g.appendChild(f); a.appendChild(d); a.style.paddingLeft = "0px"; a = t(e.L); a.innerText = " " + b; a.onmouseover = function () { this.style.color = "red" }; a.onmouseout = function () { this.style.color = "black" }; a.onclick = function () { 0 == e.o && e.S(0); e.o = !1 }
-    } else a.innerText =
-        " " + (c + 1).toString() + "- " + b, a.onmouseover = function () { this.style.background = "white"; this.style.color = "red" }, a.onmouseout = function () { this.style.background = "#c9dff2"; this.style.color = "black" }, d.onmousedown = function () { e.S(c) }
+  var e = this,
+    a = t(this.H),
+    b = this.v.K(this.items[c]);
+  var d = a.insertRow(-1);
+  d.cssText =
+    "all:revert;padding:0px;margin:0px;width:100%;line-height:100% !important;height:19px !important";
+  d.style.display = r[e.A];
+  a = d.insertCell(0);
+  a.style.cssText =
+    "all:revert;letter-spacing:normal;line-height:100% !important;width:100%;height:19px !important;margin:0px;padding:0px;padding-left:5px;vertical-align:middle;color:black !important;cursor:default;border:dotted 1px black;background:#c9dff2 !important;direction:ltr;text-align:left;font-family:tahoma !important;font-style:normal;font-weight:bold;font-size:7pt !important";
+  b = K(b);
+  if (0 == c && 1 == this.items.length) {
+    d = document.createElement("TABLE");
+    d.style.cssText =
+      "all:revert;border-spacing:0px;border-collapse:separate;padding:0px;margin:0px;width:100%;border:solid 1px black;direction:ltr;line-height:100% !important";
+    var f = d.insertRow(-1);
+    f.style.cssText =
+      "all:revert;padding:0px;margin:0px;line-height:100% !important;height:19px !important";
+    var g = f.insertCell(-1);
+    g.style.cssText =
+      "all:revert;background:#c9dff2 !important;padding:0px;margin:0px;width:20px;height:19px !important;text-align:center;vertical-align:middle;line-height:100% !important";
+    var k = document.createElement("IMG");
+    k.src = h;
+    k.onclick = function () {
+      alert("NeatDownloadManager Video/Audio Panel.");
+    };
+    g.appendChild(k);
+    g = f.insertCell(-1);
+    g.id = e.L;
+    g.style.cssText =
+      "all:revert;letter-spacing:normal;padding:0px;margin:0px;vertical-align:middle;color:black !important;cursor:default;background:#c9dff2 !important;direction:ltr;text-align:center;font-family:tahoma !important;font-style:normal;font-weight:bold;font-size:7pt !important;height:19px !important;line-height:100% !important";
+    g = f.insertCell(-1);
+    g.style.cssText =
+      "all:revert;background:#c9dff2 !important;padding:0px;margin:0px;width:20px;height:19px !important;text-align:center;vertical-align:middle;line-height:100% !important";
+    f = document.createElement("IMG");
+    f.src = q;
+    f.onclick = function () {
+      e.g.style.display = "none";
+    };
+    g.appendChild(f);
+    a.appendChild(d);
+    a.style.paddingLeft = "0px";
+    a = t(e.L);
+    a.innerText = " " + b;
+    a.onmouseover = function () {
+      this.style.color = "red";
+    };
+    a.onmouseout = function () {
+      this.style.color = "black";
+    };
+    a.onclick = function () {
+      0 == e.o && e.S(0);
+      e.o = !1;
+    };
+  } else
+    ((a.innerText = " " + (c + 1).toString() + "- " + b),
+      (a.onmouseover = function () {
+        this.style.background = "white";
+        this.style.color = "red";
+      }),
+      (a.onmouseout = function () {
+        this.style.background = "#c9dff2";
+        this.style.color = "black";
+      }),
+      (d.onmousedown = function () {
+        e.S(c);
+      }));
 };
 M.J = function (c) {
-    var e = this, a = this.v.K(c), b = null, d = this.l ? "absolute" : "fixed"; this.l && !this.u && (b = D(this.l)); b && (this.position = { left: Math.max(0, b.left - 1), top: Math.max(0, b.top - 19 - 4) }); this.g ? this.s() : (this.g = document.createElement("DIV"), this.g.style.cssText = "all:revert;padding:0px;margin:0px;position:" + d + ";z-index:100000000;width:215px;left:" + this.position.left + "px;top:" + this.position.top + "px;direction:ltr;text-align:center;background:#c9dff2 !important;line-height:100% !important;", this.g.id = "neatDiv" +
-        this.oa, this.g.style.display = this.v.C ? "" : "none", document.body.appendChild(this.g), b = document.createElement("TABLE"), b.id = this.H, b.style.cssText = "all:revert;border-spacing:0px;border-collapse:separate;padding:0px;margin:0px;line-height:100% !important;direction:ltr;width:100%;", this.g.appendChild(b), this.B(e.g, "mousemove", e.ra), this.B(e.g, "mousedown", e.qa), this.B(e.g, "mouseup", e.P), this.B(e.g, "mouseout", e.sa), this.B(e.g, "mouseover", e.ta), this.i = setTimeout(function () { e.i = null; e.g.style.opacity = .45 },
-            3E4)); if (!(-1 < this.items.indexOf(c))) {
-                a = K(a); if (this.items.length && (" MP4 File HQ" == a || " MP4 File LQ" == a)) for (b = 0; b < this.items.length; b++)if (a == K(this.v.K(this.items[b]))) { this.items[b] = c; this.g.style.display = this.v.C ? "" : "none"; this.s(); return } this.items.push(c); c = this.items.length - 1; a = t(e.H).rows; var f; c && (f = t(e.L)); 0 == c ? this.F(0) : 1 == c ? (this.F(0), this.F(1), f.onclick = function (g) { g.stopPropagation(); g.preventDefault(); 0 == e.o && e.I(); e.o = !1 }, f.innerText = " 2 Files") : (this.F(c), f.innerText = " " + (c + 1).toString() +
-                    " Files"); a[0].style.display = ""
-            }
-}; M.qa = function (c) { 0 == c.button && (this.u = !0, this.o = !1, this.N = c.clientX, this.O = c.clientY, c.stopPropagation(), c.preventDefault()) }; M.ra = function (c) { if (this.u) { this.I(!0); var e = c.clientX - this.N, a = c.clientY - this.O; !this.o && (this.o = e || a); this.position.left += e; this.position.top += a; this.N = c.clientX; this.O = c.clientY; this.s() } else this.o = !1 };
-M.sa = function () { this.u = !1; this.i && (clearTimeout(this.i), this.i = null); var c = this; this.i = setTimeout(function () { c.g.style.opacity = .45; c.i = null }, 15E3) }; M.ta = function () { this.u = !1; this.i && (clearTimeout(this.i), this.i = null); this.g.style.opacity = 1 }; M.P = function () { this.u = !1 };
-if (!window.m) {
-    var blockedHosts = []; var N = function () {
-        this.Y = null; this.D = {}; this.h = {}; this.M = !1; this.U = this.T = -1; this.Counter = 1; this.j = null; this.aa = 0; this.C = !0; this.ea = []; this.port = chrome.runtime.connect({ name: "neat" }); this.ba = Math.ceil(2E6 * Math.random()); this.port.onMessage.addListener(this.V.bind(this)); this.port.onDisconnect.addListener(this.W.bind(this)); chrome.storage.local.get(["blockedHosts"], function (result) { blockedHosts = result.blockedHosts || [] }); chrome.storage.onChanged.addListener(function (changes, namespace) { if (namespace === "local" && changes.blockedHosts) { blockedHosts = changes.blockedHosts.newValue || [] } }); if (u()) { var a = this; this.ma = new window.MutationObserver(function (b) { b.forEach(function (d) { a.ja(d.target) }) }); this.ma.observe(document, { childList: !0, subtree: !0 }) } this.m(window,
-            "keydown", this.R, !0); this.m(window, "keyup", this.R, !0); this.m(window, "mouseup", this.P, !0); this.m(window, "resize", this.na); this.m(document, "DOMContentLoaded", this.X); this.m(document, "click", this.la)
-    }; window.m = !0; M = N.prototype; M.ka = function (a, b) { b.hd && this.G({ id: B(b.hd), 1: "GET", 2: b.hd, fEx: "mp4", 4: " MP4 File HQ" }, window.location.href, a, !1); b.sd && this.G({ id: B(b.sd), 1: "GET", 2: b.sd, fEx: "mp4", 4: " MP4 File LQ" }, window.location.href, a, !1) }; M.ga = function (a) {
-        for (; (a = a.parentElement) && 1 > a.querySelectorAll("video").length;);
-        if (a) return a.querySelectorAll("video")[0]
-    }; M.da = function (a, b) { var d = this; y({ 2: "https://www.facebook.com/video/embed?video_id=" + b, pa: function (f) { var g = /"sd_src_no_ratelimit":"(.*?)"/.exec(f), k = /"hd_src_no_ratelimit":"(.*?)"/.exec(f); g && g.length || (g = /"sd_src":"(.*?)"/.exec(f)); k && k.length || (k = /"hd_src":"(.*?)"/.exec(f)); f = { sd: g && g.length ? g[1].replace(/\\/g, "") : "", hd: k && k.length ? k[1].replace(/\\/g, "") : "" }; g = d.ga(a); void 0 !== g && d.ka(g, f) } }) }; M.ja = function (a) {
-        var b = this; a = a.querySelectorAll('a[href*="/videos/"]');
-        a.length && Array.from(a, function (d) { if (!d.getAttribute("NEAT_DM")) { d.setAttribute("NEAT_DM", 1); var f = d.href.match(/.*\/videos\/(\d+)\/.*/i); f && b.da(d, f[1]) } })
-    }; M.K = function (a) { return this.D[a] }; M.va = function () { this.port.postMessage([2, this.Y, window.location.href, this.getTitle()]) }; M.X = function () {
-        for (var a = this, b = document.getElementsByTagName("SCRIPT"), d, f, g, k = /"progressive":\s*\[/, l = 0; l < b.length; l++)if (d = b[l], 0 <= document.location.host.toLowerCase().indexOf("vimeo") && !d.src && k.test(d.innerText) && (d =
-            d.innerText, f = d.indexOf('"progressive"'), !(0 > f || (g = d.indexOf("]", f), 0 > g)))) { d = d.substr(f, g - f + 1); f = null; try { f = JSON.parse("{" + d + "}") } catch (p) { } if (f) { var n = f.progressive; n && setTimeout(function () { for (var p = 0; p < n.length; p++)a.G({ id: B(n[p].url), 1: "GET", 2: n[p].url, fEx: "mp4", 4: "MP4 File " + n[p].quality }, window.location.href, null, !1) }, 2E3); break } }
-    }; M.Z = function (a) { var b = this.h[a]; if (b) { try { document.body.removeChild(b.g), b.i && clearTimeout(b.i) } catch (d) { } delete this.h[a] } }; M.ia = function (a) {
-        (a = this.D[a]) && this.port.postMessage([6,
-            a, window.location.href, this.getTitle(), K(a)])
-    }; M.fa = function (a, b) {
-        var d = null, f = ["VIDEO", "AUDIO", "OBJECT", "EMBED"]; try {
-            var g = document.activeElement, k = 0, l, n, p = g && 0 <= f.indexOf(g.tagName) ? g : null; p ||= (g = document.elementFromPoint(this.T, this.U)) && 0 <= f.indexOf(g.tagName) ? g : null; for (var v = 0; v < f.length; v++) {
-                for (var E = document.getElementsByTagName(f[v]), z = 0; z < E.length; z++)if (g = E[z], 3 != v || "application/x-shockwave-flash" == g.type.toLowerCase()) {
-                    var A = g.src || g.data; if (A && (A == a || A == b)) { var F = g; break } if (p || G) var G =
-                        g; else { var w = g.clientWidth, x = g.clientHeight; if (w && x) { var H = window.getComputedStyle(g); if (!H || "hidden" != H.visibility) { var I = w * x; x < 1.4 * w && w < 3 * x && I > k && (k = I, l = g); n ||= g } } }
-                } if (F) break
-            } (d = F || p || G || l || n) || (d = document.querySelectorAll("video,audio")[0]); if (!d) return null; if ("EMBED" == d.tagName && !d.clientWidth && !d.clientHeight) { var J = d.parentElement; "OBJECT" == J.tagName && (d = J) } return d
-        } catch (O) { return null }
-    }; M.ha = function (a) {
-        try {
-            var b = parseInt(a.getAttribute("JM_NEAT")); b || (b = this.ba << 10 | this.Counter++, a.setAttribute("JM_NEAT",
-                b)); return b
-        } catch (d) { }
-    }; M.getTitle = function () { var a = ""; try { a = document.title || document.getElementsByTagName("title")[0].innerText, a = a.trim() } catch (b) { } return a ? a = a.replace(/[ \t\r\n\u25B6]+/g, " ").trim() : "" }; M.R = function (a) { 8 != a.keyCode && 46 != a.keyCode || this.port.postMessage([4, "keydown" == a.type]) }; M.P = function (a) { 0 == a.button && (this.T = a.clientX, this.U = a.clientY) }; M.na = function () {
-        if (!this.M) {
-            this.M = !0; var a = this; window.setTimeout(function () {
-                for (var b in a.h) {
-                    var d = a.h[b], f = null; d.l && (f = D(d.l)); if (f) {
-                        try { document.body.removeChild(d.g) } catch (g) { } d.position.left =
-                            Math.max(0, f.left - 1); d.position.top = Math.max(0, f.top - 19 - 4); document.body.appendChild(d.g)
-                    } d.s()
-                } a.M = !1
-            }, 500)
+  var e = this,
+    a = this.v.K(c),
+    b = null,
+    d = this.l ? "absolute" : "fixed";
+  this.l && !this.u && (b = D(this.l));
+  b &&
+    (this.position = {
+      left: Math.max(0, b.left - 1),
+      top: Math.max(0, b.top - 19 - 4),
+    });
+  this.g
+    ? this.s()
+    : ((this.g = document.createElement("DIV")),
+      (this.g.style.cssText =
+        "all:revert;padding:0px;margin:0px;position:" +
+        d +
+        ";z-index:100000000;width:215px;left:" +
+        this.position.left +
+        "px;top:" +
+        this.position.top +
+        "px;direction:ltr;text-align:center;background:#c9dff2 !important;line-height:100% !important;"),
+      (this.g.id = "neatDiv" + this.oa),
+      (this.g.style.display = this.v.C ? "" : "none"),
+      document.body.appendChild(this.g),
+      (b = document.createElement("TABLE")),
+      (b.id = this.H),
+      (b.style.cssText =
+        "all:revert;border-spacing:0px;border-collapse:separate;padding:0px;margin:0px;line-height:100% !important;direction:ltr;width:100%;"),
+      this.g.appendChild(b),
+      this.B(e.g, "mousemove", e.ra),
+      this.B(e.g, "mousedown", e.qa),
+      this.B(e.g, "mouseup", e.P),
+      this.B(e.g, "mouseout", e.sa),
+      this.B(e.g, "mouseover", e.ta),
+      (this.i = setTimeout(function () {
+        e.i = null;
+        e.g.style.opacity = 0.45;
+      }, 3e4)));
+  if (!(-1 < this.items.indexOf(c))) {
+    a = K(a);
+    if (this.items.length && (" MP4 File HQ" == a || " MP4 File LQ" == a))
+      for (b = 0; b < this.items.length; b++)
+        if (a == K(this.v.K(this.items[b]))) {
+          this.items[b] = c;
+          this.g.style.display = this.v.C ? "" : "none";
+          this.s();
+          return;
         }
-    }; function c(a, b) { return 18 > Math.abs(a.left - b.left) && 18 > Math.abs(a.top - b.top) } function e(a) { a = D(a.l); return !a || 0 > a.left || 0 > a.top } M.G = function (a, b, d, f) {
-        if (blockedHosts && blockedHosts.length > 0) { var currentHostname = window.location.hostname; var isBlocked = blockedHosts.some(function (host) { var blockRegex = new RegExp("(^|\\.)" + host.replace(/\./g, "\\.") + "$", "i"); return blockRegex.test(currentHostname) }); if (isBlocked) { return } } var g = this, k = -1, l = null, n; f = f && RegExp(".*facebook.com$|.*vimeo.com$|.*youtube.com$", "i").test(window.location.host) && !(a.fEx && "VTT" == a.fEx.toUpperCase()) && !(!a.fS || 5242880 < a.fS); if (a.fEx && ("VTT" == a.fEx.toUpperCase() || "SRT" == a.fEx.toUpperCase())) {
-            if (0 <=
-                window.location.host.toLowerCase().indexOf("youtube.")) return; this.aa++; if (2 < this.aa) return
-        } if (!(0 <= window.location.host.toLowerCase().indexOf("youtube.com"))) {
-            a.id || (a.id = B(a["2"])); d ||= this.fa(a["2"], b); if (!d) for (n in this.h) { l = this.h[n]; k = n; break } if (!d && !l) { if (f) return; l = new L(g, null, 0) } else if (!l) if (k = this.ha(d), l = this.h[k], !l) {
-                if (f) return; l = new L(g, d, k); b = D(d); d = { left: Math.max(0, b.left - 1), top: Math.max(0, b.top - 19 - 4) }; for (n in this.h) if (n && n != k && (b = this.h[n], c(d, b.position))) {
-                    for (d = 0; d < b.items.length; d++)l.J(b.items[d]);
-                    this.Z(n); break
-                } if (0 != k && this.h[0]) { b = this.h[0]; for (d = 0; d < b.items.length; d++)l.J(b.items[d]); this.Z(0) }
-            } else { if (f) { l.s(); return } } else if (f) { l.s(); return } g.D[a.id] = a; l.J(a.id); l.l && e(l) && !this.j && (g.j = setInterval(function () { g.ca(l) }, 1200))
-        }
-    }; M.ca = function (a) { if (a && a.l) { var b = D(a.l); b && (a.position = { left: Math.max(0, b.left - 1), top: Math.max(0, b.top - 19 - 4) }, a.s()); !b || 0 > b.left || 0 > b.top || (clearInterval(this.j), this.j = null) } else clearInterval(this.j), this.j = null }; M.V = function (a) {
-        var b = this; switch (a[0]) {
-            case 1: b.G(a[1],
-                a[2], null, !0); break; case 3: (a = a[1]) && (b.Y = a); b.va(); break; case 5: b.$(); break; case 11: b.ua(); 0 <= (new URL(window.location.href)).hostname.toLowerCase().indexOf("youtube.") || setTimeout(function () { b.X() }, 2500); break; case 13: a = a[1]; a != b.C && (b.C = a, b.$()); break; case 15: alert("Extension Can't Connect to NeatDownloadManager Application, You Can : \r\n1- Check If NeatDownloadManager is Running.\r\n2- or Hold down Delete-Key and click on the Download link.\r\n3- or Disable NeatDownloadManager Extension temporarily.")
-        }
-    };
-    M.m = function (a) { var b = Array.prototype.slice.call(arguments); b[2] = b[2].bind(this); this.ea.push(b); a.addEventListener.apply(a, b.slice(1)) }; M.la = function () { for (var a in this.h) this.h[a].I(!0) }; M.ua = function () { try { for (var a in this.h) this.h[a].i && clearTimeout(this.h[a].i), document.body.removeChild(this.h[a].g) } catch (b) { } this.h = {}; this.D = {}; this.j && clearInterval(this.j); this.j = null }; M.$ = function () { var a = this.C ? "" : "none"; try { for (var b in this.h) this.h[b].g.style.display = a } catch (d) { } }; M.W = function () {
-        this.port =
-        chrome.runtime.connect({ name: "neat" }); this.port.onMessage.addListener(this.V.bind(this)); this.port.onDisconnect.addListener(this.W.bind(this))
-    }; new N
+    this.items.push(c);
+    c = this.items.length - 1;
+    a = t(e.H).rows;
+    var f;
+    c && (f = t(e.L));
+    0 == c
+      ? this.F(0)
+      : 1 == c
+        ? (this.F(0),
+          this.F(1),
+          (f.onclick = function (g) {
+            g.stopPropagation();
+            g.preventDefault();
+            0 == e.o && e.I();
+            e.o = !1;
+          }),
+          (f.innerText = " 2 Files"))
+        : (this.F(c), (f.innerText = " " + (c + 1).toString() + " Files"));
+    a[0].style.display = "";
+  }
 };
+M.qa = function (c) {
+  0 == c.button &&
+    ((this.u = !0),
+    (this.o = !1),
+    (this.N = c.clientX),
+    (this.O = c.clientY),
+    c.stopPropagation(),
+    c.preventDefault());
+};
+M.ra = function (c) {
+  if (this.u) {
+    this.I(!0);
+    var e = c.clientX - this.N,
+      a = c.clientY - this.O;
+    !this.o && (this.o = e || a);
+    this.position.left += e;
+    this.position.top += a;
+    this.N = c.clientX;
+    this.O = c.clientY;
+    this.s();
+  } else this.o = !1;
+};
+M.sa = function () {
+  this.u = !1;
+  this.i && (clearTimeout(this.i), (this.i = null));
+  var c = this;
+  this.i = setTimeout(function () {
+    c.g.style.opacity = 0.45;
+    c.i = null;
+  }, 15e3);
+};
+M.ta = function () {
+  this.u = !1;
+  this.i && (clearTimeout(this.i), (this.i = null));
+  this.g.style.opacity = 1;
+};
+M.P = function () {
+  this.u = !1;
+};
+if (!window.m) {
+  var blockedHosts = [];
+  var catchEnabled = true;
+  var N = function () {
+    this.Y = null;
+    this.D = {};
+    this.h = {};
+    this.M = !1;
+    this.U = this.T = -1;
+    this.Counter = 1;
+    this.j = null;
+    this.aa = 0;
+    this.C = !0;
+    this.ea = [];
+    this.port = chrome.runtime.connect({ name: "neat" });
+    this.ba = Math.ceil(2e6 * Math.random());
+    this.port.onMessage.addListener(this.V.bind(this));
+    this.port.onDisconnect.addListener(this.W.bind(this));
+    chrome.storage.local.get(["blockedHosts", "ndmCatchEnabled"], function (result) {
+      blockedHosts = result.blockedHosts || [];
+      catchEnabled = result.ndmCatchEnabled !== false;
+    });
+    chrome.storage.onChanged.addListener(function (changes, namespace) {
+      if (namespace === "local") {
+        if (changes.blockedHosts) {
+          blockedHosts = changes.blockedHosts.newValue || [];
+        }
+        if (changes.ndmCatchEnabled) {
+          catchEnabled = changes.ndmCatchEnabled.newValue !== false;
+        }
+      }
+    });
+    if (u()) {
+      var a = this;
+      this.ma = new window.MutationObserver(function (b) {
+        b.forEach(function (d) {
+          a.ja(d.target);
+        });
+      });
+      this.ma.observe(document, { childList: !0, subtree: !0 });
+    }
+    this.m(window, "keydown", this.R, !0);
+    this.m(window, "keyup", this.R, !0);
+    this.m(window, "mouseup", this.P, !0);
+    this.m(window, "resize", this.na);
+    this.m(document, "DOMContentLoaded", this.X);
+    this.m(document, "click", this.la);
+  };
+  window.m = !0;
+  M = N.prototype;
+  M.ka = function (a, b) {
+    b.hd &&
+      this.G(
+        { id: B(b.hd), 1: "GET", 2: b.hd, fEx: "mp4", 4: " MP4 File HQ" },
+        window.location.href,
+        a,
+        !1,
+      );
+    b.sd &&
+      this.G(
+        { id: B(b.sd), 1: "GET", 2: b.sd, fEx: "mp4", 4: " MP4 File LQ" },
+        window.location.href,
+        a,
+        !1,
+      );
+  };
+  M.ga = function (a) {
+    for (; (a = a.parentElement) && 1 > a.querySelectorAll("video").length; );
+    if (a) return a.querySelectorAll("video")[0];
+  };
+  M.da = function (a, b) {
+    var d = this;
+    y({
+      2: "https://www.facebook.com/video/embed?video_id=" + b,
+      pa: function (f) {
+        var g = /"sd_src_no_ratelimit":"(.*?)"/.exec(f),
+          k = /"hd_src_no_ratelimit":"(.*?)"/.exec(f);
+        (g && g.length) || (g = /"sd_src":"(.*?)"/.exec(f));
+        (k && k.length) || (k = /"hd_src":"(.*?)"/.exec(f));
+        f = {
+          sd: g && g.length ? g[1].replace(/\\/g, "") : "",
+          hd: k && k.length ? k[1].replace(/\\/g, "") : "",
+        };
+        g = d.ga(a);
+        void 0 !== g && d.ka(g, f);
+      },
+    });
+  };
+  M.ja = function (a) {
+    var b = this;
+    a = a.querySelectorAll('a[href*="/videos/"]');
+    a.length &&
+      Array.from(a, function (d) {
+        if (!d.getAttribute("NEAT_DM")) {
+          d.setAttribute("NEAT_DM", 1);
+          var f = d.href.match(/.*\/videos\/(\d+)\/.*/i);
+          f && b.da(d, f[1]);
+        }
+      });
+  };
+  M.K = function (a) {
+    return this.D[a];
+  };
+  M.va = function () {
+    this.port.postMessage([2, this.Y, window.location.href, this.getTitle()]);
+  };
+  M.X = function () {
+    for (
+      var a = this,
+        b = document.getElementsByTagName("SCRIPT"),
+        d,
+        f,
+        g,
+        k = /"progressive":\s*\[/,
+        l = 0;
+      l < b.length;
+      l++
+    )
+      if (
+        ((d = b[l]),
+        0 <= document.location.host.toLowerCase().indexOf("vimeo") &&
+          !d.src &&
+          k.test(d.innerText) &&
+          ((d = d.innerText),
+          (f = d.indexOf('"progressive"')),
+          !(0 > f || ((g = d.indexOf("]", f)), 0 > g))))
+      ) {
+        d = d.substr(f, g - f + 1);
+        f = null;
+        try {
+          f = JSON.parse("{" + d + "}");
+        } catch (p) {}
+        if (f) {
+          var n = f.progressive;
+          n &&
+            setTimeout(function () {
+              for (var p = 0; p < n.length; p++)
+                a.G(
+                  {
+                    id: B(n[p].url),
+                    1: "GET",
+                    2: n[p].url,
+                    fEx: "mp4",
+                    4: "MP4 File " + n[p].quality,
+                  },
+                  window.location.href,
+                  null,
+                  !1,
+                );
+            }, 2e3);
+          break;
+        }
+      }
+  };
+  M.Z = function (a) {
+    var b = this.h[a];
+    if (b) {
+      try {
+        (document.body.removeChild(b.g), b.i && clearTimeout(b.i));
+      } catch (d) {}
+      delete this.h[a];
+    }
+  };
+  M.ia = function (a) {
+    (a = this.D[a]) &&
+      this.port.postMessage([
+        6,
+        a,
+        window.location.href,
+        this.getTitle(),
+        K(a),
+      ]);
+  };
+  M.fa = function (a, b) {
+    var d = null,
+      f = ["VIDEO", "AUDIO", "OBJECT", "EMBED"];
+    try {
+      var g = document.activeElement,
+        k = 0,
+        l,
+        n,
+        p = g && 0 <= f.indexOf(g.tagName) ? g : null;
+      p ||=
+        (g = document.elementFromPoint(this.T, this.U)) &&
+        0 <= f.indexOf(g.tagName)
+          ? g
+          : null;
+      for (var v = 0; v < f.length; v++) {
+        for (
+          var E = document.getElementsByTagName(f[v]), z = 0;
+          z < E.length;
+          z++
+        )
+          if (
+            ((g = E[z]),
+            3 != v || "application/x-shockwave-flash" == g.type.toLowerCase())
+          ) {
+            var A = g.src || g.data;
+            if (A && (A == a || A == b)) {
+              var F = g;
+              break;
+            }
+            if (p || G) var G = g;
+            else {
+              var w = g.clientWidth,
+                x = g.clientHeight;
+              if (w && x) {
+                var H = window.getComputedStyle(g);
+                if (!H || "hidden" != H.visibility) {
+                  var I = w * x;
+                  x < 1.4 * w && w < 3 * x && I > k && ((k = I), (l = g));
+                  n ||= g;
+                }
+              }
+            }
+          }
+        if (F) break;
+      }
+      (d = F || p || G || l || n) ||
+        (d = document.querySelectorAll("video,audio")[0]);
+      if (!d) return null;
+      if ("EMBED" == d.tagName && !d.clientWidth && !d.clientHeight) {
+        var J = d.parentElement;
+        "OBJECT" == J.tagName && (d = J);
+      }
+      return d;
+    } catch (O) {
+      return null;
+    }
+  };
+  M.ha = function (a) {
+    try {
+      var b = parseInt(a.getAttribute("JM_NEAT"));
+      b ||
+        ((b = (this.ba << 10) | this.Counter++), a.setAttribute("JM_NEAT", b));
+      return b;
+    } catch (d) {}
+  };
+  M.getTitle = function () {
+    var a = "";
+    try {
+      ((a =
+        document.title || document.getElementsByTagName("title")[0].innerText),
+        (a = a.trim()));
+    } catch (b) {}
+    return a ? (a = a.replace(/[ \t\r\n\u25B6]+/g, " ").trim()) : "";
+  };
+  M.R = function (a) {
+    (8 != a.keyCode && 46 != a.keyCode) ||
+      this.port.postMessage([4, "keydown" == a.type]);
+  };
+  M.P = function (a) {
+    0 == a.button && ((this.T = a.clientX), (this.U = a.clientY));
+  };
+  M.na = function () {
+    if (!this.M) {
+      this.M = !0;
+      var a = this;
+      window.setTimeout(function () {
+        for (var b in a.h) {
+          var d = a.h[b],
+            f = null;
+          d.l && (f = D(d.l));
+          if (f) {
+            try {
+              document.body.removeChild(d.g);
+            } catch (g) {}
+            d.position.left = Math.max(0, f.left - 1);
+            d.position.top = Math.max(0, f.top - 19 - 4);
+            document.body.appendChild(d.g);
+          }
+          d.s();
+        }
+        a.M = !1;
+      }, 500);
+    }
+  };
+  function c(a, b) {
+    return 18 > Math.abs(a.left - b.left) && 18 > Math.abs(a.top - b.top);
+  }
+  function e(a) {
+    a = D(a.l);
+    return !a || 0 > a.left || 0 > a.top;
+  }
+  M.G = function (a, b, d, f) {
+    if (blockedHosts && blockedHosts.length > 0) {
+      var currentHostname = window.location.hostname;
+      var isBlocked = blockedHosts.some(function (host) {
+        var blockRegex = new RegExp(
+          "(^|\\.)" + host.replace(/\./g, "\\.") + "$",
+          "i",
+        );
+        return blockRegex.test(currentHostname);
+      });
+      if (isBlocked) {
+        return;
+      }
+    }
+    var g = this,
+      k = -1,
+      l = null,
+      n;
+    f =
+      f &&
+      RegExp(".*facebook.com$|.*vimeo.com$|.*youtube.com$", "i").test(
+        window.location.host,
+      ) &&
+      !(a.fEx && "VTT" == a.fEx.toUpperCase()) &&
+      !(!a.fS || 5242880 < a.fS);
+    if (
+      a.fEx &&
+      ("VTT" == a.fEx.toUpperCase() || "SRT" == a.fEx.toUpperCase())
+    ) {
+      if (0 <= window.location.host.toLowerCase().indexOf("youtube.")) return;
+      this.aa++;
+      if (2 < this.aa) return;
+    }
+    if (!(0 <= window.location.host.toLowerCase().indexOf("youtube.com"))) {
+      a.id || (a.id = B(a["2"]));
+      d ||= this.fa(a["2"], b);
+      if (!d)
+        for (n in this.h) {
+          l = this.h[n];
+          k = n;
+          break;
+        }
+      if (!d && !l) {
+        if (f) return;
+        l = new L(g, null, 0);
+      } else if (!l)
+        if (((k = this.ha(d)), (l = this.h[k]), !l)) {
+          if (f) return;
+          l = new L(g, d, k);
+          b = D(d);
+          d = {
+            left: Math.max(0, b.left - 1),
+            top: Math.max(0, b.top - 19 - 4),
+          };
+          for (n in this.h)
+            if (n && n != k && ((b = this.h[n]), c(d, b.position))) {
+              for (d = 0; d < b.items.length; d++) l.J(b.items[d]);
+              this.Z(n);
+              break;
+            }
+          if (0 != k && this.h[0]) {
+            b = this.h[0];
+            for (d = 0; d < b.items.length; d++) l.J(b.items[d]);
+            this.Z(0);
+          }
+        } else {
+          if (f) {
+            l.s();
+            return;
+          }
+        }
+      else if (f) {
+        l.s();
+        return;
+      }
+      g.D[a.id] = a;
+      l.J(a.id);
+      l.l &&
+        e(l) &&
+        !this.j &&
+        (g.j = setInterval(function () {
+          g.ca(l);
+        }, 1200));
+    }
+  };
+  M.ca = function (a) {
+    if (a && a.l) {
+      var b = D(a.l);
+      b &&
+        ((a.position = {
+          left: Math.max(0, b.left - 1),
+          top: Math.max(0, b.top - 19 - 4),
+        }),
+        a.s());
+      !b || 0 > b.left || 0 > b.top || (clearInterval(this.j), (this.j = null));
+    } else (clearInterval(this.j), (this.j = null));
+  };
+  M.V = function (a) {
+    var b = this;
+    switch (a[0]) {
+      case 1:
+        b.G(a[1], a[2], null, !0);
+        break;
+      case 3:
+        (a = a[1]) && (b.Y = a);
+        b.va();
+        break;
+      case 5:
+        b.$();
+        break;
+      case 11:
+        b.ua();
+        0 <=
+          new URL(window.location.href).hostname
+            .toLowerCase()
+            .indexOf("youtube.") ||
+          setTimeout(function () {
+            b.X();
+          }, 2500);
+        break;
+      case 13:
+        a = a[1];
+        a != b.C && ((b.C = a), b.$());
+        break;
+      case 15:
+        alert(
+          "Extension Can't Connect to NeatDownloadManager Application, You Can : \r\n1- Check If NeatDownloadManager is Running.\r\n2- or Hold down Delete-Key and click on the Download link.\r\n3- or Disable NeatDownloadManager Extension temporarily.",
+        );
+    }
+  };
+  M.m = function (a) {
+    var b = Array.prototype.slice.call(arguments);
+    b[2] = b[2].bind(this);
+    this.ea.push(b);
+    a.addEventListener.apply(a, b.slice(1));
+  };
+  M.la = function () {
+    for (var a in this.h) this.h[a].I(!0);
+  };
+  M.ua = function () {
+    try {
+      for (var a in this.h)
+        (this.h[a].i && clearTimeout(this.h[a].i),
+          document.body.removeChild(this.h[a].g));
+    } catch (b) {}
+    this.h = {};
+    this.D = {};
+    this.j && clearInterval(this.j);
+    this.j = null;
+  };
+  M.$ = function () {
+    var a = this.C ? "" : "none";
+    try {
+      for (var b in this.h) this.h[b].g.style.display = a;
+    } catch (d) {}
+  };
+  M.W = function () {
+    this.port = chrome.runtime.connect({ name: "neat" });
+    this.port.onMessage.addListener(this.V.bind(this));
+    this.port.onDisconnect.addListener(this.W.bind(this));
+  };
+  window.neatDownloadManagerExtensionInstance = new N();
+}
 
-document.addEventListener('click', function (e) {
-    // 检查是否按住了 Ctrl 键
-    if (!e.ctrlKey) return;
+function isDownloadLink(target, href) {
+  if (!href) return false;
+  if (target.hasAttribute("download")) return true;
+  var extMatch = href.match(/\.([a-z0-9]{1,8})(?:[?#]|$)/i);
+  if (!extMatch) return false;
+  var ext = extMatch[1].toLowerCase();
+  return /^(zip|exe|dmg|pdf|mp4|m4a|mp3|jpg|jpeg|png|gif|svg|rar|7z|tar|gz|iso|apk|docx?|xlsx?|pptx?|txt|csv|ppt|mpg|mpeg|mkv|avi|wmv|flv|mov|webm|ogg|opus)$/i.test(ext);
+}
 
-    // 获取实际点击的链接元素
-    let target = e.target.closest('a');
-    if (!target) return;
+function isBlockedHost(hostname) {
+  if (!hostname || !blockedHosts || blockedHosts.length === 0) return false;
+  return blockedHosts.some(function (host) {
+    var blockRegex = new RegExp("(^|\\.)" + host.replace(/\./g, "\\.") + "$", "i");
+    return blockRegex.test(hostname);
+  });
+}
 
-    // 获取链接的 href 属性
-    let href = target.href;
-    if (!href) return;
+// #sym:sendDownloadLinkToBg
+// 仅保留此函数作为 ct.js 到 bg.js 的下载链接传递入口。
+function sendDownloadLinkToBg(url) {
+  if (!url) return;
+  chrome.runtime.sendMessage({
+    action: "downloadLink",
+    url: url,
+    pageUrl: window.location.href,
+    title: document.title || "",
+  });
+}
 
-    // 发送消息给后台，通知该 URL 需要临时放行
-    chrome.runtime.sendMessage({ action: 'tempWhitelist', url: href });
-}, true); // 使用捕获阶段以确保能尽早处理
+function handleLinkClick(e) {
+  if (e.button != 0) return;
+
+  var target = e.target.closest("a[href]");
+  if (!target) return;
+
+  var href = target.href;
+  if (!href || !/^(https?|ftp):/i.test(href)) return;
+  if (!isDownloadLink(target, href)) return;
+
+  var currentHost = window.location.hostname;
+  if (isBlockedHost(currentHost)) return;
+
+  try {
+    var linkHost = new URL(href).hostname;
+    if (isBlockedHost(linkHost)) return;
+  } catch (ignored) {}
+
+  if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
+    return;
+  }
+
+  if (!catchEnabled) return;
+
+  e.preventDefault();
+  e.stopImmediatePropagation();
+  //console.log("NDM DEBUG: sending download link to bg:", href);
+  sendDownloadLinkToBg(href);
+}
+
+document.addEventListener("click", handleLinkClick, true);


### PR DESCRIPTION
1.优化绕过NDM下载的逻辑，提高成功率；
2.修复某些情况下blockhosts失效、关闭扩展失效的问题；
3.修复上下文菜单block download和ublock download名称更新不及时问题；
3.增加绕过下载的热键，现在按住ctrl、alt、Windows/Command、shift按键点击下载链接均可绕过NDM进行下载。